### PR TITLE
Update costa_rica01.yml

### DIFF
--- a/conf/cr/costa_rica01.yml
+++ b/conf/cr/costa_rica01.yml
@@ -52,11 +52,11 @@ years:
     names:
       en: "New Year's Day"
   - public_holiday: true
-    date: '2019-03-18'
+    date: '2019-04-18'
     names:
       en: 'Good Thursday'
   - public_holiday: true
-    date: '2019-03-19'
+    date: '2019-04-19'
     names:
       en: 'Good Friday'
   - public_holiday: true


### PR DESCRIPTION
Easter public holidays were set in March instead of April