### PR TITLE
Remove trailing commas and whitespace

### DIFF
--- a/conf/au/australia07.yml
+++ b/conf/au/australia07.yml
@@ -25,7 +25,7 @@ years:
   - public_holiday: true
     date: '2011-04-23'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2011-04-24'
     names:
@@ -78,7 +78,7 @@ years:
   - public_holiday: true
     date: '2012-04-07'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2012-04-08'
     names:
@@ -127,7 +127,7 @@ years:
   - public_holiday: true
     date: '2013-03-30'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2013-03-31'
     names:
@@ -176,7 +176,7 @@ years:
   - public_holiday: true
     date: '2014-04-19'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2014-04-20'
     names:
@@ -225,7 +225,7 @@ years:
   - public_holiday: true
     date: '2015-04-04'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2015-04-05'
     names:
@@ -282,7 +282,7 @@ years:
   - public_holiday: true
     date: '2016-03-26'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2016-03-27'
     names:
@@ -339,7 +339,7 @@ years:
   - public_holiday: true
     date: '2017-04-15'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2017-04-16'
     names:
@@ -388,7 +388,7 @@ years:
   - public_holiday: true
     date: '2018-03-31'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2018-04-01'
     names:
@@ -437,7 +437,7 @@ years:
   - public_holiday: true
     date: '2019-04-20'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2019-04-21'
     names:
@@ -490,7 +490,7 @@ years:
   - public_holiday: true
     date: '2020-04-11'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2020-04-12'
     names:
@@ -543,7 +543,7 @@ years:
   - public_holiday: true
     date: '2021-04-03'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2021-04-04'
     names:
@@ -596,7 +596,7 @@ years:
   - public_holiday: true
     date: '2022-04-16'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2022-04-17'
     names:
@@ -649,7 +649,7 @@ years:
   - public_holiday: true
     date: '2023-04-08'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2023-04-09'
     names:
@@ -698,7 +698,7 @@ years:
   - public_holiday: true
     date: '2024-03-30'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2024-03-31'
     names:
@@ -747,7 +747,7 @@ years:
   - public_holiday: true
     date: '2025-04-19'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2025-04-20'
     names:
@@ -796,7 +796,7 @@ years:
   - public_holiday: true
     date: '2026-04-04'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2026-04-05'
     names:
@@ -849,7 +849,7 @@ years:
   - public_holiday: true
     date: '2027-03-27'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2027-03-28'
     names:
@@ -902,7 +902,7 @@ years:
   - public_holiday: true
     date: '2028-04-15'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2028-04-16'
     names:
@@ -951,7 +951,7 @@ years:
   - public_holiday: true
     date: '2029-03-31'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2029-04-01'
     names:
@@ -1000,7 +1000,7 @@ years:
   - public_holiday: true
     date: '2030-04-20'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2030-04-21'
     names:
@@ -1049,7 +1049,7 @@ years:
   - public_holiday: true
     date: '2031-04-12'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2031-04-13'
     names:
@@ -1098,7 +1098,7 @@ years:
   - public_holiday: true
     date: '2032-03-27'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2032-03-28'
     names:
@@ -1151,7 +1151,7 @@ years:
   - public_holiday: true
     date: '2033-04-16'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2033-04-17'
     names:
@@ -1204,7 +1204,7 @@ years:
   - public_holiday: true
     date: '2034-04-08'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2034-04-09'
     names:
@@ -1253,7 +1253,7 @@ years:
   - public_holiday: true
     date: '2035-03-24'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2035-03-25'
     names:
@@ -1302,7 +1302,7 @@ years:
   - public_holiday: true
     date: '2036-04-12'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2036-04-13'
     names:
@@ -1351,7 +1351,7 @@ years:
   - public_holiday: true
     date: '2037-04-04'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2037-04-05'
     names:
@@ -1404,7 +1404,7 @@ years:
   - public_holiday: true
     date: '2038-04-24'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2038-04-25'
     names:
@@ -1457,7 +1457,7 @@ years:
   - public_holiday: true
     date: '2039-04-09'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2039-04-10'
     names:
@@ -1510,7 +1510,7 @@ years:
   - public_holiday: true
     date: '2040-03-31'
     names:
-      en: 'The Saturday before Easter Sunday '
+      en: 'The Saturday before Easter Sunday'
   - public_holiday: true
     date: '2040-04-01'
     names:

--- a/conf/ch/switzerland01.yml
+++ b/conf/ch/switzerland01.yml
@@ -5,35 +5,35 @@ years:
   - public_holiday: true
     date: '2019-01-01'
     names:
-      en: New Years Day,
+      en: New Years Day
   - public_holiday: true
     date: '2019-04-19'
     names:
-      en: Good Friday,
+      en: Good Friday
   - public_holiday: true
     date: '2019-04-22'
     names:
-      en: Easter Monday,
+      en: Easter Monday
   - public_holiday: true
     date: '2019-05-30'
     names:
-      en: Ascension Day,
+      en: Ascension Day
   - public_holiday: true
     date: '2019-06-10'
     names:
-      en: Whit Monday,
+      en: Whit Monday
   - public_holiday: true
     date: '2019-08-01'
     names:
-      en: National Day,
+      en: National Day
   - public_holiday: true
     date: '2019-09-05'
     names:
-      en: Jeûne genevois,
+      en: Jeûne genevois
   - public_holiday: true
     date: '2019-12-25'
     names:
-      en: Christmas Day,
+      en: Christmas Day
   - public_holiday: true
     date: '2019-12-31'
     names:
@@ -42,35 +42,35 @@ years:
   - public_holiday: true
     date: '2020-01-01'
     names:
-      en: New Years Day,
+      en: New Years Day
   - public_holiday: true
     date: '2020-04-10'
     names:
-      en: Good Friday,
+      en: Good Friday
   - public_holiday: true
     date: '2020-04-13'
     names:
-      en: Easter Monday,
+      en: Easter Monday
   - public_holiday: true
     date: '2020-05-21'
     names:
-      en: Ascension Day,
+      en: Ascension Day
   - public_holiday: true
     date: '2020-06-01'
     names:
-      en: Whit Monday,
+      en: Whit Monday
   - public_holiday: true
     date: '2020-08-01'
     names:
-      en: National Day,
+      en: National Day
   - public_holiday: true
     date: '2020-09-10'
     names:
-      en: Jeûne genevois,
+      en: Jeûne genevois
   - public_holiday: true
     date: '2020-12-25'
     names:
-      en: Christmas Day,
+      en: Christmas Day
   - public_holiday: true
     date: '2020-12-31'
     names:

--- a/conf/ch/zurich.yml
+++ b/conf/ch/zurich.yml
@@ -4,147 +4,147 @@ years:
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
+    names:
       en: New Year's Day
-      de: Neujahr,
+      de: Neujahr
   - public_holiday: true
     date: '2019-01-02'
-    names: 
+    names:
       en: Berchtolds Day
-      de: Berchtoldstag,
+      de: Berchtoldstag
   - public_holiday: true
     date: '2019-04-08'
-    names: 
+    names:
       en: Sechseläuten
-      de: Sechseläuten,
+      de: Sechseläuten
   - public_holiday: true
     date: '2019-04-18'
-    names: 
+    names:
       en: Maundy Thursday
-      de: Gründonnerstag,
+      de: Gründonnerstag
   - public_holiday: true
     date: '2019-04-19'
-    names: 
+    names:
       en: Good Friday
-      de: Karfreitag,
+      de: Karfreitag
   - public_holiday: true
     date: '2019-04-22'
-    names: 
+    names:
       en: Easter Monday
-      de: Ostermontag,
+      de: Ostermontag
   - public_holiday: true
     date: '2019-05-01'
-    names: 
+    names:
       en: May Day
-      de: Tag der Arbeit,
+      de: Tag der Arbeit
   - public_holiday: true
     date: '2019-05-29'
-    names: 
+    names:
       en: Mittwoch vor Auffahrt
-      de: Mittwoch vor Auffahrt,
+      de: Mittwoch vor Auffahrt
   - public_holiday: true
     date: '2019-05-30'
-    names: 
+    names:
       en: Ascension Day
-      de: Auffahrt,
+      de: Auffahrt
   - public_holiday: true
     date: '2019-06-10'
-    names: 
+    names:
       en: Whit Monday
-      de: Pfingstmontag,
+      de: Pfingstmontag
   - public_holiday: true
     date: '2019-08-01'
-    names: 
+    names:
       en: National Day
-      de: Nationalfeiertag,
+      de: Nationalfeiertag
   - public_holiday: true
     date: '2019-09-09'
-    names: 
+    names:
       en: Knabenschiessen
-      de: Knabenschiessen,
+      de: Knabenschiessen
   - public_holiday: true
     date: '2019-12-24'
-    names: 
+    names:
       en: Christmas Eve
-      de: Heiligabend,
+      de: Heiligabend
   - public_holiday: true
     date: '2019-12-25'
-    names: 
+    names:
       en: Christmas Day
-      de: Weihnachten,
+      de: Weihnachten
   - public_holiday: true
     date: '2019-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
-      de: Stephanstag,
+      de: Stephanstag
   - public_holiday: true
     date: '2019-12-31'
-    names: 
+    names:
       en: New Year's Eve
       de: Silvester
   '2020':
   - public_holiday: true
     date: '2020-01-01'
-    names: 
+    names:
       en: New Year's Day
-      de: Neujahr,
+      de: Neujahr
   - public_holiday: true
     date: '2020-01-02'
-    names: 
+    names:
       en: Berchtolds Day
-      de: Berchtoldstag,
+      de: Berchtoldstag
   - public_holiday: true
     date: '2020-04-09'
-    names: 
+    names:
       en: Maundy Thursday
-      de: Gründonnerstag,
+      de: Gründonnerstag
   - public_holiday: true
     date: '2020-04-10'
-    names: 
+    names:
       en: Good Friday
-      de: Karfreitag,
+      de: Karfreitag
   - public_holiday: true
     date: '2020-04-13'
-    names: 
+    names:
       en: Easter Monday
-      de: Ostermontag,
+      de: Ostermontag
   - public_holiday: true
     date: '2020-05-01'
-    names: 
+    names:
       en: May Day
-      de: Tag der Arbeit,
+      de: Tag der Arbeit
   - public_holiday: true
     date: '2020-05-20'
-    names: 
+    names:
       en: Mittwoch vor Auffahrt
-      de: Mittwoch vor Auffahrt,
+      de: Mittwoch vor Auffahrt
   - public_holiday: true
     date: '2020-05-21'
-    names: 
+    names:
       en: Ascension Day
-      de: Auffahrt,
+      de: Auffahrt
   - public_holiday: true
     date: '2020-06-01'
-    names: 
+    names:
       en: Whit Monday
-      de: Pfingstmontag,
+      de: Pfingstmontag
   - public_holiday: true
     date: '2020-09-14'
-    names: 
+    names:
       en: Knabenschiessen
-      de: Knabenschiessen,
+      de: Knabenschiessen
   - public_holiday: true
     date: '2020-12-24'
-    names: 
+    names:
       en: Christmas Eve
-      de: Heiligabend,
+      de: Heiligabend
   - public_holiday: true
     date: '2020-12-25'
-    names: 
+    names:
       en: Christmas Day
-      de: Weihnachten,
+      de: Weihnachten
   - public_holiday: true
     date: '2020-12-31'
-    names: 
+    names:
       en: New Year's Eve
       de: Silvester

--- a/conf/de/germany03.yml
+++ b/conf/de/germany03.yml
@@ -384,7 +384,7 @@ years:
     date: '2019-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag    
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2019-04-19'
     names:
@@ -435,7 +435,7 @@ years:
     date: '2020-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag  
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2020-04-10'
     names:
@@ -486,7 +486,7 @@ years:
     date: '2021-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag  
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2021-04-02'
     names:
@@ -537,7 +537,7 @@ years:
     date: '2022-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2022-04-15'
     names:
@@ -588,7 +588,7 @@ years:
     date: '2023-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2023-04-07'
     names:
@@ -639,7 +639,7 @@ years:
     date: '2024-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2024-03-29'
     names:
@@ -690,7 +690,7 @@ years:
     date: '2025-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2025-04-18'
     names:
@@ -741,7 +741,7 @@ years:
     date: '2026-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2026-04-03'
     names:
@@ -792,7 +792,7 @@ years:
     date: '2027-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2027-03-26'
     names:
@@ -843,7 +843,7 @@ years:
     date: '2028-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2028-04-14'
     names:
@@ -894,7 +894,7 @@ years:
     date: '2029-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2029-03-30'
     names:
@@ -945,7 +945,7 @@ years:
     date: '2030-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2030-04-19'
     names:
@@ -996,7 +996,7 @@ years:
     date: '2031-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2031-04-11'
     names:
@@ -1047,7 +1047,7 @@ years:
     date: '2032-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2032-03-26'
     names:
@@ -1098,7 +1098,7 @@ years:
     date: '2033-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2033-04-15'
     names:
@@ -1149,7 +1149,7 @@ years:
     date: '2034-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2034-04-07'
     names:
@@ -1200,7 +1200,7 @@ years:
     date: '2035-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2035-03-23'
     names:
@@ -1251,7 +1251,7 @@ years:
     date: '2036-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2036-04-11'
     names:
@@ -1302,7 +1302,7 @@ years:
     date: '2037-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2037-04-03'
     names:
@@ -1353,7 +1353,7 @@ years:
     date: '2038-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2038-04-23'
     names:
@@ -1404,7 +1404,7 @@ years:
     date: '2039-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2039-04-08'
     names:
@@ -1455,7 +1455,7 @@ years:
     date: '2040-03-08'
     names:
       en: World Women's Day
-      de: Internationaler Frauentag 
+      de: Internationaler Frauentag
   - public_holiday: true
     date: '2040-03-30'
     names:

--- a/conf/de/germany15.yml
+++ b/conf/de/germany15.yml
@@ -4,244 +4,244 @@ years:
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       de: Neujahrstag
   - public_holiday: true
     date: '2018-03-30'
-    names: 
+    names:
       en: Good Friday
       de: Karfreitag
   - public_holiday: true
     date: '2018-04-02'
-    names: 
+    names:
       en: Easter Monday
       de: Ostermontag
   - public_holiday: true
     date: '2018-05-01'
-    names: 
+    names:
       en: Labour Day
       de: Tag der Arbeit
   - public_holiday: true
     date: '2018-05-10'
-    names: 
+    names:
       en: Ascension Day
       de: Christi Himmelfahrt
   - public_holiday: true
     date: '2018-05-21'
-    names: 
+    names:
       en: Whit Monday
       de: Pfingstmontag
   - public_holiday: true
     date: '2018-05-31'
-    names: 
+    names:
       en: Corpus Christi
       de: Fronleichnam
   - public_holiday: true
     date: '2018-10-03'
-    names: 
+    names:
       en: German Unity Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-10-31'
-    names: 
+    names:
       en: Reformation Day
       de: Reformationstag
   - public_holiday: true
     date: '2018-11-21'
-    names: 
+    names:
       en: Day of Repentance and Prayer
       de: Buß- und Bettag
   - public_holiday: true
     date: '2018-12-25'
-    names: 
+    names:
       en: Christmas Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
       de: Zweiter Weihnachtsfeiertag
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       de: Neujahrstag
   - public_holiday: true
     date: '2018-03-30'
-    names: 
+    names:
       en: Good Friday
       de: Karfreitag
   - public_holiday: true
     date: '2018-04-02'
-    names: 
+    names:
       en: Easter Monday
       de: Ostermontag
   - public_holiday: true
     date: '2018-05-01'
-    names: 
+    names:
       en: Labour Day
       de: Tag der Arbeit
   - public_holiday: true
     date: '2018-05-10'
-    names: 
+    names:
       en: Ascension Day
       de: Christi Himmelfahrt
   - public_holiday: true
     date: '2018-05-21'
-    names: 
+    names:
       en: Whit Monday
       de: Pfingstmontag
   - public_holiday: true
     date: '2018-05-31'
-    names: 
+    names:
       en: Corpus Christi
       de: Fronleichnam
   - public_holiday: true
     date: '2018-10-03'
-    names: 
+    names:
       en: German Unity Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-10-31'
-    names: 
+    names:
       en: Reformation Day
       de: Reformationstag
   - public_holiday: true
     date: '2018-11-21'
-    names: 
+    names:
       en: Day of Repentance and Prayer
       de: Buß- und Bettag
   - public_holiday: true
     date: '2018-12-25'
-    names: 
+    names:
       en: Christmas Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
       de: Zweiter Weihnachtsfeiertag
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       de: Neujahrstag
   - public_holiday: true
     date: '2018-03-30'
-    names: 
+    names:
       en: Good Friday
       de: Karfreitag
   - public_holiday: true
     date: '2018-04-02'
-    names: 
+    names:
       en: Easter Monday
       de: Ostermontag
   - public_holiday: true
     date: '2018-05-01'
-    names: 
+    names:
       en: Labour Day
       de: Tag der Arbeit
   - public_holiday: true
     date: '2018-05-10'
-    names: 
+    names:
       en: Ascension Day
       de: Christi Himmelfahrt
   - public_holiday: true
     date: '2018-05-21'
-    names: 
+    names:
       en: Whit Monday
       de: Pfingstmontag
   - public_holiday: true
     date: '2018-05-31'
-    names: 
+    names:
       en: Corpus Christi
       de: Fronleichnam
   - public_holiday: true
     date: '2018-10-03'
-    names: 
+    names:
       en: German Unity Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-10-31'
-    names: 
+    names:
       en: Reformation Day
       de: Reformationstag
   - public_holiday: true
     date: '2018-11-21'
-    names: 
+    names:
       en: Day of Repentance and Prayer
       de: Buß- und Bettag
   - public_holiday: true
     date: '2018-12-25'
-    names: 
+    names:
       en: Christmas Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
       de: Zweiter Weihnachtsfeiertag
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
+    names:
       en: New Year's Day
       de: Neujahrstag
   - public_holiday: true
     date: '2019-04-19'
-    names: 
+    names:
       en: Good Friday
       de: Karfreitag
   - public_holiday: true
     date: '2019-04-22'
-    names: 
+    names:
       en: Easter Monday
       de: Ostermontag
   - public_holiday: true
     date: '2019-05-01'
-    names: 
+    names:
       en: Labour Day
       de: Tag der Arbeit
   - public_holiday: true
     date: '2019-05-30'
-    names: 
+    names:
       en: Ascension Day
       de: Christi Himmelfahrt
   - public_holiday: true
     date: '2019-06-10'
-    names: 
+    names:
       en: Whit Monday
       de: Pfingstmontag
   - public_holiday: true
     date: '2019-06-20'
-    names: 
+    names:
       en: Corpus Christi
       de: Fronleichnam
   - public_holiday: true
     date: '2019-10-03'
-    names: 
+    names:
       en: German Unity Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2019-10-31'
-    names: 
+    names:
       en: Reformation Day
       de: Reformationstag
   - public_holiday: true
     date: '2019-11-20'
-    names: 
+    names:
       en: Day of Repentance and Prayer
       de: Buß- und Bettag
   - public_holiday: true
     date: '2019-12-25'
-    names: 
+    names:
       en: Christmas Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2019-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
       de: Zweiter Weihnachtsfeiertag

--- a/conf/de/germany16.yml
+++ b/conf/de/germany16.yml
@@ -1,207 +1,207 @@
 ---
-name: Saxony-Anhalt 
+name: Saxony-Anhalt
 years:
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       de: Neujahrstag
   - public_holiday: true
     date: '2018-03-30'
-    names: 
+    names:
       en: Good Friday
       de: Karfreitag
   - public_holiday: true
     date: '2018-04-02'
-    names: 
+    names:
       en: Easter Monday
       de: Ostermontag
   - public_holiday: true
     date: '2018-05-01'
-    names: 
+    names:
       en: Labour Day
       de: Tag der Arbeit
   - public_holiday: true
     date: '2018-05-10'
-    names: 
+    names:
       en: Ascension Day
       de: Christi Himmelfahrt
   - public_holiday: true
     date: '2018-05-21'
-    names: 
+    names:
       en: Whit Monday
       de: Pfingstmontag
   - public_holiday: true
     date: '2018-10-03'
-    names: 
+    names:
       en: German Unity Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-10-31'
-    names: 
+    names:
       en: Reformation Day
       de: Reformationstag
   - public_holiday: true
     date: '2018-12-25'
-    names: 
+    names:
       en: Christmas Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
       de: Zweiter Weihnachtsfeiertag
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       de: Neujahrstag
   - public_holiday: true
     date: '2018-03-30'
-    names: 
+    names:
       en: Good Friday
       de: Karfreitag
   - public_holiday: true
     date: '2018-04-02'
-    names: 
+    names:
       en: Easter Monday
       de: Ostermontag
   - public_holiday: true
     date: '2018-05-01'
-    names: 
+    names:
       en: Labour Day
       de: Tag der Arbeit
   - public_holiday: true
     date: '2018-05-10'
-    names: 
+    names:
       en: Ascension Day
       de: Christi Himmelfahrt
   - public_holiday: true
     date: '2018-05-21'
-    names: 
+    names:
       en: Whit Monday
       de: Pfingstmontag
   - public_holiday: true
     date: '2018-10-03'
-    names: 
+    names:
       en: German Unity Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-10-31'
-    names: 
+    names:
       en: Reformation Day
       de: Reformationstag
   - public_holiday: true
     date: '2018-12-25'
-    names: 
+    names:
       en: Christmas Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
       de: Zweiter Weihnachtsfeiertag
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       de: Neujahrstag
   - public_holiday: true
     date: '2018-03-30'
-    names: 
+    names:
       en: Good Friday
       de: Karfreitag
   - public_holiday: true
     date: '2018-04-02'
-    names: 
+    names:
       en: Easter Monday
       de: Ostermontag
   - public_holiday: true
     date: '2018-05-01'
-    names: 
+    names:
       en: Labour Day
       de: Tag der Arbeit
   - public_holiday: true
     date: '2018-05-10'
-    names: 
+    names:
       en: Ascension Day
       de: Christi Himmelfahrt
   - public_holiday: true
     date: '2018-05-21'
-    names: 
+    names:
       en: Whit Monday
       de: Pfingstmontag
   - public_holiday: true
     date: '2018-10-03'
-    names: 
+    names:
       en: German Unity Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-10-31'
-    names: 
+    names:
       en: Reformation Day
       de: Reformationstag
   - public_holiday: true
     date: '2018-12-25'
-    names: 
+    names:
       en: Christmas Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2018-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
       de: Zweiter Weihnachtsfeiertag
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
+    names:
       en: New Year's Day
       de: Neujahrstag
   - public_holiday: true
     date: '2019-04-19'
-    names: 
+    names:
       en: Good Friday
       de: Karfreitag
   - public_holiday: true
     date: '2019-04-22'
-    names: 
+    names:
       en: Easter Monday
       de: Ostermontag
   - public_holiday: true
     date: '2019-05-01'
-    names: 
+    names:
       en: Labour Day
       de: Tag der Arbeit
   - public_holiday: true
     date: '2019-05-30'
-    names: 
+    names:
       en: Ascension Day
       de: Christi Himmelfahrt
   - public_holiday: true
     date: '2019-06-10'
-    names: 
+    names:
       en: Whit Monday
       de: Pfingstmontag
   - public_holiday: true
     date: '2019-10-03'
-    names: 
+    names:
       en: German Unity Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2019-10-31'
-    names: 
+    names:
       en: Reformation Day
       de: Reformationstag
   - public_holiday: true
     date: '2019-12-25'
-    names: 
+    names:
       en: Christmas Day
       de: Tag der Deutschen Einheit
   - public_holiday: true
     date: '2019-12-26'
-    names: 
+    names:
       en: St. Stephen's Day
       de: Zweiter Weihnachtsfeiertag

--- a/conf/es/asturias.yml
+++ b/conf/es/asturias.yml
@@ -3,112 +3,112 @@ years:
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
+    names:
       en: New Year's Day
-      es: New Year's Day,
+      es: New Year's Day
   - public_holiday: true
     date: '2019-01-06'
-    names: 
-      en: Epiphany 
-      es: Epiphany ,
+    names:
+      en: Epiphany
+      es: Epiphany
   - public_holiday: true
     date: '2019-01-07'
-    names: 
-      en: Good Friday 
-      es: Good Friday ,
+    names:
+      en: Good Friday
+      es: Good Friday
   - public_holiday: true
     date: '2019-04-18'
-    names: 
+    names:
       en: Labour Day
-      es: Labour Day,
+      es: Labour Day
   - public_holiday: true
     date: '2019-09-09'
-    names: 
+    names:
       en: Day of Asturias
-      es: Day of Asturias,
+      es: Day of Asturias
   - public_holiday: true
     date: '2019-10-12'
-    names: 
+    names:
       en: Hispanic Day
-      es: Hispanic Day,
+      es: Hispanic Day
   - public_holiday: true
     date: '2019-11-01'
-    names: 
+    names:
       en: All Saints' Day
-      es: All Saints' Day,
+      es: All Saints' Day
   - public_holiday: true
     date: '2019-12-06'
-    names: 
+    names:
       en: Constitution Day
-      es: Constitution Day,
+      es: Constitution Day
   - public_holiday: true
     date: '2019-12-08'
-    names: 
+    names:
       en: Immaculate Conception Day
-      es: Immaculate Conception Day,
+      es: Immaculate Conception Day
   - public_holiday: true
     date: '2019-12-25'
-    names: 
+    names:
       en: Christmas Day
       es: Christmas Day
   '2020':
   - public_holiday: true
     date: '2020-01-01'
-    names: 
+    names:
       en: New Year's Day
-      es: New Year's Day,
+      es: New Year's Day
   - public_holiday: true
     date: '2020-01-06'
-    names: 
-      en: Epiphany 
-      es: Epiphany ,
+    names:
+      en: Epiphany
+      es: Epiphany
   - public_holiday: true
     date: '2020-04-09'
-    names: 
+    names:
       en: Holy Thursday
-      es: Holy Thursday,
+      es: Holy Thursday
   - public_holiday: true
     date: '2020-04-23'
-    names: 
-      en: Good Friday 
-      es: Good Friday ,
+    names:
+      en: Good Friday
+      es: Good Friday
   - public_holiday: true
     date: '2020-05-01'
-    names: 
+    names:
       en: Labour Day
-      es: Labour Day,
+      es: Labour Day
   - public_holiday: true
     date: '2020-08-15'
-    names: 
+    names:
       en: Assumption Day
-      es: Assumption Day,
+      es: Assumption Day
   - public_holiday: true
     date: '2020-09-08'
-    names: 
+    names:
       en: Day of Asturias
-      es: Day of Asturias,
+      es: Day of Asturias
   - public_holiday: true
     date: '2020-10-12'
-    names: 
+    names:
       en: Hispanic Day
-      es: Hispanic Day,
+      es: Hispanic Day
   - public_holiday: true
     date: '2020-11-01'
-    names: 
+    names:
       en: All Saints' Day
-      es: All Saints' Day,
+      es: All Saints' Day
   - public_holiday: true
     date: '2020-12-06'
-    names: 
+    names:
       en: Constitution Day
-      es: Constitution Day,
+      es: Constitution Day
   - public_holiday: true
     date: '2020-12-08'
-    names: 
+    names:
       en: Immaculate Conception Day
-      es: Immaculate Conception Day,
+      es: Immaculate Conception Day
   - public_holiday: true
     date: '2020-12-25'
-    names: 
+    names:
       en: Christmas Day
       es: Christmas Day

--- a/conf/es/castile-and-leon.yml
+++ b/conf/es/castile-and-leon.yml
@@ -1,124 +1,124 @@
-name: Castile and León 
+name: Castile and León
 years:
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
+    names:
       en: New Year's Day
-      es: New Year's Day,
+      es: New Year's Day
   - public_holiday: true
     date: '2019-01-06'
-    names: 
-      en: Epiphany 
-      es: Epiphany ,
+    names:
+      en: Epiphany
+      es: Epiphany
   - public_holiday: true
     date: '2019-01-07'
-    names: 
+    names:
       en: Good Friday
-      es: Good Friday,
+      es: Good Friday
   - public_holiday: true
     date: '2019-04-18'
-    names: 
+    names:
       en: Castile and León Community Day
-      es: Castile and León Community Day,
+      es: Castile and León Community Day
   - public_holiday: true
     date: '2019-05-01'
-    names: 
+    names:
       en: Labour Day
-      es: Labour Day,
+      es: Labour Day
   - public_holiday: true
     date: '2019-08-15'
-    names: 
+    names:
       en: Assumption Day
-      es: Assumption Day,
+      es: Assumption Day
   - public_holiday: true
     date: '2019-10-12'
-    names: 
+    names:
       en: Hispanic Day
-      es: Hispanic Day,
+      es: Hispanic Day
   - public_holiday: true
     date: '2019-11-01'
-    names: 
+    names:
       en: All Saint's Day
-      es: All Saint's Day,
+      es: All Saint's Day
   - public_holiday: true
     date: '2019-12-06'
-    names: 
+    names:
       en: Constituion Day
-      es: Constituion Day,
+      es: Constituion Day
   - public_holiday: true
     date: '2019-12-08'
-    names: 
+    names:
       en: Immaculate Conception Day
-      es: Immaculate Conception Day,
+      es: Immaculate Conception Day
   - public_holiday: true
     date: '2019-12-09'
-    names: 
+    names:
       en: Immaculate Conception Holiday
-      es: Immaculate Conception Holiday,
+      es: Immaculate Conception Holiday
   - public_holiday: true
     date: '2019-12-25'
-    names: 
+    names:
       en: Christmas Day
       es: Christmas Day
   '2020':
   - public_holiday: true
     date: '2020-01-01'
-    names: 
+    names:
       en: New Year's Day
-      es: New Year's Day,
+      es: New Year's Day
   - public_holiday: true
     date: '2020-01-06'
-    names: 
-      en: Epiphany 
-      es: Epiphany ,
+    names:
+      en: Epiphany
+      es: Epiphany
   - public_holiday: true
     date: '2020-04-09'
-    names: 
+    names:
       en: Holy Thursday
-      es: Holy Thursday,
+      es: Holy Thursday
   - public_holiday: true
     date: '2020-04-10'
-    names: 
+    names:
       en: Good Friday
-      es: Good Friday,
+      es: Good Friday
   - public_holiday: true
     date: '2020-04-23'
-    names: 
+    names:
       en: Castile and León Community Day
-      es: Castile and León Community Day,
+      es: Castile and León Community Day
   - public_holiday: true
     date: '2020-05-01'
-    names: 
+    names:
       en: Labour Day
-      es: Labour Day,
+      es: Labour Day
   - public_holiday: true
     date: '2020-08-15'
-    names: 
+    names:
       en: Assumption Day
-      es: Assumption Day,
+      es: Assumption Day
   - public_holiday: true
     date: '2020-10-12'
-    names: 
+    names:
       en: Hispanic Day
-      es: Hispanic Day,
+      es: Hispanic Day
   - public_holiday: true
     date: '2020-11-01'
-    names: 
+    names:
       en: All Saint's Day
-      es: All Saint's Day,
+      es: All Saint's Day
   - public_holiday: true
     date: '2020-12-06'
-    names: 
+    names:
       en: Constituion Day
-      es: Constituion Day,
+      es: Constituion Day
   - public_holiday: true
     date: '2020-12-08'
-    names: 
+    names:
       en: Immaculate Conception Day
-      es: Immaculate Conception Day,
+      es: Immaculate Conception Day
   - public_holiday: true
     date: '2020-12-25'
-    names: 
+    names:
       en: Christmas Day
       es: Christmas Day

--- a/conf/es/galicia.yml
+++ b/conf/es/galicia.yml
@@ -3,127 +3,127 @@ years:
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
+    names:
       en: New Year's Day
-      es: New Year's Day,
+      es: New Year's Day
   - public_holiday: true
     date: '2019-01-06'
-    names: 
-      en: Epiphany 
-      es: Epiphany ,
+    names:
+      en: Epiphany
+      es: Epiphany
   - public_holiday: true
     date: '2019-03-19'
-    names: 
-      en: Good Friday 
-      es: Good Friday ,
+    names:
+      en: Good Friday
+      es: Good Friday
   - public_holiday: true
     date: '2019-04-18'
-    names: 
+    names:
       en: Labour Day
-      es: Labour Day,
+      es: Labour Day
   - public_holiday: true
     date: '2019-05-17'
-    names: 
+    names:
       en: Galician Literature Day
-      es: Galician Literature Day,
+      es: Galician Literature Day
   - public_holiday: true
     date: '2019-07-25'
-    names: 
+    names:
       en: St. James' Day
-      es: St. James' Day,
+      es: St. James' Day
   - public_holiday: true
     date: '2019-08-15'
-    names: 
+    names:
       en: Assumption Day
-      es: Assumption Day,
+      es: Assumption Day
   - public_holiday: true
     date: '2019-10-12'
-    names: 
+    names:
       en: Hispanic Day
-      es: Hispanic Day,
+      es: Hispanic Day
   - public_holiday: true
     date: '2019-11-01'
-    names: 
+    names:
       en: All Saints' Day
-      es: All Saints' Day,
+      es: All Saints' Day
   - public_holiday: true
     date: '2019-12-06'
-    names: 
+    names:
       en: Constitution Day
-      es: Constitution Day,
+      es: Constitution Day
   - public_holiday: true
     date: '2019-12-08'
-    names: 
+    names:
       en: Immaculate Conception Day
-      es: Immaculate Conception Day,
+      es: Immaculate Conception Day
   - public_holiday: true
     date: '2019-12-25'
-    names: 
+    names:
       en: Christmas Day
       es: Christmas Day
   '2020':
   - public_holiday: true
     date: '2020-01-01'
-    names: 
+    names:
       en: New Year's Day
-      es: New Year's Day,
+      es: New Year's Day
   - public_holiday: true
     date: '2020-01-06'
-    names: 
-      en: Epiphany 
-      es: Epiphany ,
+    names:
+      en: Epiphany
+      es: Epiphany
   - public_holiday: true
     date: '2020-04-09'
-    names: 
+    names:
       en: Holy Thursday
-      es: Holy Thursday,
+      es: Holy Thursday
   - public_holiday: true
     date: '2020-04-23'
-    names: 
-      en: Good Friday 
-      es: Good Friday ,
+    names:
+      en: Good Friday
+      es: Good Friday
   - public_holiday: true
     date: '2020-05-01'
-    names: 
+    names:
       en: Labour Day
-      es: Labour Day,
+      es: Labour Day
   - public_holiday: true
     date: '2020-05-17'
-    names: 
+    names:
       en: Galician Literature Day
-      es: Galician Literature Day,
+      es: Galician Literature Day
   - public_holiday: true
     date: '2020-07-25'
-    names: 
+    names:
       en: St. James' Day
-      es: St. James' Day,
+      es: St. James' Day
   - public_holiday: true
     date: '2020-08-15'
-    names: 
+    names:
       en: Assumption Day
-      es: Assumption Day,
+      es: Assumption Day
   - public_holiday: true
     date: '2020-10-12'
-    names: 
+    names:
       en: Hispanic Day
-      es: Hispanic Day,
+      es: Hispanic Day
   - public_holiday: true
     date: '2020-11-01'
-    names: 
+    names:
       en: All Saints' Day
-      es: All Saints' Day,
+      es: All Saints' Day
   - public_holiday: true
     date: '2020-12-06'
-    names: 
+    names:
       en: Constitution Day
-      es: Constitution Day,
+      es: Constitution Day
   - public_holiday: true
     date: '2020-12-08'
-    names: 
+    names:
       en: Immaculate Conception Day
-      es: Immaculate Conception Day,
+      es: Immaculate Conception Day
   - public_holiday: true
     date: '2020-12-25'
-    names: 
+    names:
       en: Christmas Day
       es: Christmas Day

--- a/conf/mn/mongolia01.yml
+++ b/conf/mn/mongolia01.yml
@@ -4,355 +4,355 @@ years:
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       mn: New Year's Day
   - public_holiday: true
     date: '2018-02-16'
-    names: 
+    names:
       en: Lunar New Year
       mn: Lunar New Year
   - public_holiday: true
     date: '2018-02-17'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2018-02-18'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2018-03-08'
-    names: 
+    names:
       en: International Women's Day
       mn: International Women's Day
   - public_holiday: true
     date: '2018-06-01'
-    names: 
-      en: Mother's and Children's Day 
-      mn: Mother's and Children's Day 
+    names:
+      en: Mother's and Children's Day
+      mn: Mother's and Children's Day
   - public_holiday: true
     date: '2018-07-11'
-    names: 
+    names:
       en: Naadam
       mn: Naadam
   - public_holiday: true
     date: '2018-07-12'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-13'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-14'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-15'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-11-01'
-    names: 
+    names:
       en: Genghis Khan's Birthday
       mn: Genghis Khan's Birthday
   - public_holiday: true
     date: '2018-11-26'
-    names: 
+    names:
       en: Republic's Day
       mn: Republic's Day
   - public_holiday: true
     date: '2018-12-29'
-    names: 
+    names:
       en: Independance Day
       mn: Indpendance Day
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       mn: New Year's Day
   - public_holiday: true
     date: '2018-02-16'
-    names: 
+    names:
       en: Lunar New Year
       mn: Lunar New Year
   - public_holiday: true
     date: '2018-02-17'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2018-02-18'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2018-03-08'
-    names: 
+    names:
       en: International Women's Day
       mn: International Women's Day
   - public_holiday: true
     date: '2018-06-01'
-    names: 
-      en: Mother's and Children's Day 
-      mn: Mother's and Children's Day 
+    names:
+      en: Mother's and Children's Day
+      mn: Mother's and Children's Day
   - public_holiday: true
     date: '2018-07-11'
-    names: 
+    names:
       en: Naadam
       mn: Naadam
   - public_holiday: true
     date: '2018-07-12'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-13'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-14'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-15'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-11-01'
-    names: 
+    names:
       en: Genghis Khan's Birthday
       mn: Genghis Khan's Birthday
   - public_holiday: true
     date: '2018-11-26'
-    names: 
+    names:
       en: Republic's Day
       mn: Republic's Day
   - public_holiday: true
     date: '2018-12-29'
-    names: 
+    names:
       en: Independance Day
       mn: Indpendance Day
   '2018':
   - public_holiday: true
     date: '2018-01-01'
-    names: 
+    names:
       en: New Year's Day
       mn: New Year's Day
   - public_holiday: true
     date: '2018-02-16'
-    names: 
+    names:
       en: Lunar New Year
       mn: Lunar New Year
   - public_holiday: true
     date: '2018-02-17'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2018-02-18'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2018-03-08'
-    names: 
+    names:
       en: International Women's Day
       mn: International Women's Day
   - public_holiday: true
     date: '2018-06-01'
-    names: 
-      en: Mother's and Children's Day 
-      mn: Mother's and Children's Day 
+    names:
+      en: Mother's and Children's Day
+      mn: Mother's and Children's Day
   - public_holiday: true
     date: '2018-07-11'
-    names: 
+    names:
       en: Naadam
       mn: Naadam
   - public_holiday: true
     date: '2018-07-12'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-13'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-14'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-07-15'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2018-11-01'
-    names: 
+    names:
       en: Genghis Khan's Birthday
       mn: Genghis Khan's Birthday
   - public_holiday: true
     date: '2018-11-26'
-    names: 
+    names:
       en: Republic's Day
       mn: Republic's Day
   - public_holiday: true
     date: '2018-12-29'
-    names: 
+    names:
       en: Independance Day
       mn: Indpendance Day
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
+    names:
       en: New Year's Day
       mn: New Year's Day
   - public_holiday: true
     date: '2019-02-05'
-    names: 
+    names:
       en: Lunar New Year
       mn: Lunar New Year
   - public_holiday: true
     date: '2019-02-06'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2019-02-07'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2019-03-08'
-    names: 
+    names:
       en: International Women's Day
       mn: International Women's Day
   - public_holiday: true
     date: '2019-06-01'
-    names: 
-      en: Mother's and Children's Day 
-      mn: Mother's and Children's Day 
+    names:
+      en: Mother's and Children's Day
+      mn: Mother's and Children's Day
   - public_holiday: true
     date: '2019-07-11'
-    names: 
+    names:
       en: Naadam
       mn: Naadam
   - public_holiday: true
     date: '2019-07-12'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2019-07-13'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2019-07-14'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2019-07-15'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2019-11-19'
-    names: 
+    names:
       en: Genghis Khan's Birthday
       mn: Genghis Khan's Birthday
   - public_holiday: true
     date: '2019-11-26'
-    names: 
+    names:
       en: Republic's Day
       mn: Republic's Day
   - public_holiday: true
     date: '2019-12-29'
-    names: 
+    names:
       en: Independance Day
       mn: Independance Day
   '2020':
   - public_holiday: true
     date: '2020-01-01'
-    names: 
+    names:
       en: New Year's Day
       mn: New Year's Day
   - public_holiday: true
     date: '2020-01-25'
-    names: 
+    names:
       en: Lunar New Year
       mn: Lunar New Year
   - public_holiday: true
     date: '2020-01-26'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2020-01-27'
-    names: 
+    names:
       en: Lunar New Year Holiday
       mn: Lunar New Year Holiday
   - public_holiday: true
     date: '2020-03-08'
-    names: 
+    names:
       en: International Women's Day
       mn: International Women's Day
   - public_holiday: true
     date: '2020-06-01'
-    names: 
-      en: Mother's and Children's Day 
-      mn: Mother's and Children's Day 
+    names:
+      en: Mother's and Children's Day
+      mn: Mother's and Children's Day
   - public_holiday: true
     date: '2020-07-11'
-    names: 
+    names:
       en: Naadam
       mn: Naadam
   - public_holiday: true
     date: '2020-07-12'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2020-07-14'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2020-07-15'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2020-07-20'
-    names: 
+    names:
       en: Naadam Holiday
       mn: Naadam Holiday
   - public_holiday: true
     date: '2020-11-16'
-    names: 
+    names:
       en: Genghis Khan's Birthday
       mn: Genghis Khan's Birthday
   - public_holiday: true
     date: '2020-11-26'
-    names: 
+    names:
       en: Republic's Day
       mn: Republic's Day
   - public_holiday: true
     date: '2020-12-29'
-    names: 
+    names:
       en: Independance Day
       mn: Independance Day

--- a/conf/mu/maurtius01.yml
+++ b/conf/mu/maurtius01.yml
@@ -4,114 +4,114 @@ years:
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
-      en: New Year's Day,
+    names:
+      en: New Year's Day
   - public_holiday: true
     date: '2019-01-02'
-    names: 
-      en: New Year's Day Holiday,
+    names:
+      en: New Year's Day Holiday
   - public_holiday: true
     date: '2019-01-21'
-    names: 
-      en: Thaipoosam Cavadee,
+    names:
+      en: Thaipoosam Cavadee
   - public_holiday: true
     date: '2019-02-01'
-    names: 
-      en: Abolition of Slavery,
+    names:
+      en: Abolition of Slavery
   - public_holiday: true
     date: '2019-02-05'
-    names: 
-      en: Chinese Spring Festival,
+    names:
+      en: Chinese Spring Festival
   - public_holiday: true
     date: '2019-03-04'
-    names: 
-      en: Maha Shivaratree,
+    names:
+      en: Maha Shivaratree
   - public_holiday: true
     date: '2019-03-12'
-    names: 
-      en: Independance and Republic Day,
+    names:
+      en: Independance and Republic Day
   - public_holiday: true
     date: '2019-04-06'
-    names: 
-      en: Ougadi,
+    names:
+      en: Ougadi
   - public_holiday: true
     date: '2019-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2019-06-05'
-    names: 
-      en: Eid-Ul-Fitr,
+    names:
+      en: Eid-Ul-Fitr
   - public_holiday: true
     date: '2019-09-03'
-    names: 
-      en: Ganesh Chaturthi ,
+    names:
+      en: Ganesh Chaturthi
   - public_holiday: true
     date: '2019-10-27'
-    names: 
-      en: Diwali,
+    names:
+      en: Diwali
   - public_holiday: true
     date: '2019-11-01'
-    names: 
-      en: All Saints Day,
+    names:
+      en: All Saints Day
   - public_holiday: true
     date: '2019-11-02'
-    names: 
-      en: Arrival of Indentured Labourers,
+    names:
+      en: Arrival of Indentured Labourers
   - public_holiday: true
     date: '2019-12-25'
-    names: 
+    names:
       en: Christmas Day
   '2020':
   - public_holiday: true
     date: '2020-01-01'
-    names: 
-      en: New Year's Day,
+    names:
+      en: New Year's Day
   - public_holiday: true
     date: '2020-01-02'
-    names: 
-      en: New Year's Day Holiday,
+    names:
+      en: New Year's Day Holiday
   - public_holiday: true
     date: '2020-01-25'
-    names: 
-      en: Chinese Spring Festival,
+    names:
+      en: Chinese Spring Festival
   - public_holiday: true
     date: '2020-02-01'
-    names: 
-      en: Abolition of Slavery,
+    names:
+      en: Abolition of Slavery
   - public_holiday: true
     date: '2020-02-08'
-    names: 
-      en: Thaipoosam Cavadee,
+    names:
+      en: Thaipoosam Cavadee
   - public_holiday: true
     date: '2020-02-21'
-    names: 
-      en: Maha Shivaratree,
+    names:
+      en: Maha Shivaratree
   - public_holiday: true
     date: '2020-03-25'
-    names: 
-      en: Ougadi,
+    names:
+      en: Ougadi
   - public_holiday: true
     date: '2020-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2020-05-24'
-    names: 
-      en: Eid-Ul-Fitr,
+    names:
+      en: Eid-Ul-Fitr
   - public_holiday: true
     date: '2020-08-23'
-    names: 
-      en: Ganesh Chaturthi ,
+    names:
+      en: Ganesh Chaturthi
   - public_holiday: true
     date: '2020-11-02'
-    names: 
-      en: Arrival of Indentured Labourers,
+    names:
+      en: Arrival of Indentured Labourers
   - public_holiday: true
     date: '2020-11-14'
-    names: 
-      en: Diwali,
+    names:
+      en: Diwali
   - public_holiday: true
     date: '2020-12-25'
-    names: 
+    names:
       en: Christmas Day

--- a/conf/my/malaysia01.yml
+++ b/conf/my/malaysia01.yml
@@ -143,7 +143,7 @@ years:
     date: '2019-06-05'
     names:
       en: End of Ramadan
-      ms: Hari Raya Aidilfitri,
+      ms: Hari Raya Aidilfitri
   - public_holiday: true
     date: '2019-06-06'
     names:
@@ -209,7 +209,7 @@ years:
     date: '2020-05-24'
     names:
       en: End of Ramadan
-      ms: Hari Raya Aidilfitri,
+      ms: Hari Raya Aidilfitri
   - public_holiday: true
     date: '2020-05-25'
     names:

--- a/conf/om/oman01.yml
+++ b/conf/om/oman01.yml
@@ -4,162 +4,162 @@ years:
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
+    names:
       en: New Year's Day
-      ar: New Year's Day,
+      ar: New Year's Day
   - public_holiday: true
     date: '2019-04-03'
-    names: 
+    names:
       en: Isra'a Wal Miraj
-      ar: Isra'a Wal Miraj,
+      ar: Isra'a Wal Miraj
   - public_holiday: true
     date: '2019-06-04'
-    names: 
+    names:
       en: Eid Al Fitr
-      ar: Eid Al Fitr,
+      ar: Eid Al Fitr
   - public_holiday: true
     date: '2019-06-05'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2019-06-06'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2019-06-07'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2019-07-23'
-    names: 
+    names:
       en: Renaissance Day
-      ar: Renaissance Day,
+      ar: Renaissance Day
   - public_holiday: true
     date: '2019-08-11'
-    names: 
+    names:
       en: Arafat Day
-      ar: Arafat Day,
+      ar: Arafat Day
   - public_holiday: true
     date: '2019-08-12'
-    names: 
+    names:
       en: Eid Al Fitr
-      ar: Eid Al Fitr,
+      ar: Eid Al Fitr
   - public_holiday: true
     date: '2019-08-13'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2019-08-14'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2019-08-15'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2019-08-31'
-    names: 
+    names:
       en: Hijri New Year
-      ar: Hijri New Year,
+      ar: Hijri New Year
   - public_holiday: true
     date: '2019-11-09'
-    names: 
+    names:
       en: Birthday of Prophet Muhammad
-      ar: Birthday of Prophet Muhammad,
+      ar: Birthday of Prophet Muhammad
   - public_holiday: true
     date: '2019-11-18'
-    names: 
+    names:
       en: National Day
-      ar: National Day,
+      ar: National Day
   - public_holiday: true
     date: '2019-11-19'
-    names: 
+    names:
       en: Sultan's Birthday
       ar: Sultan's Birthday
   '2020':
   - public_holiday: true
     date: '2020-01-01'
-    names: 
+    names:
       en: New Year's Day
-      ar: New Year's Day,
+      ar: New Year's Day
   - public_holiday: true
     date: '2020-03-22'
-    names: 
+    names:
       en: Isra'a Wal Miraj
-      ar: Isra'a Wal Miraj,
+      ar: Isra'a Wal Miraj
   - public_holiday: true
     date: '2020-05-24'
-    names: 
+    names:
       en: Eid Al Fitr
-      ar: Eid Al Fitr,
+      ar: Eid Al Fitr
   - public_holiday: true
     date: '2020-05-25'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2020-05-26'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2020-05-27'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2020-07-23'
-    names: 
+    names:
       en: Renaissance Day
-      ar: Renaissance Day,
+      ar: Renaissance Day
   - public_holiday: true
     date: '2020-07-30'
-    names: 
+    names:
       en: Arafat Day
-      ar: Arafat Day,
+      ar: Arafat Day
   - public_holiday: true
     date: '2020-07-31'
-    names: 
+    names:
       en: Eid Al Fitr
-      ar: Eid Al Fitr,
+      ar: Eid Al Fitr
   - public_holiday: true
     date: '2020-08-01'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2020-08-02'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2020-08-03'
-    names: 
+    names:
       en: Eid Al Fitr Holiday
-      ar: Eid Al Fitr Holiday,
+      ar: Eid Al Fitr Holiday
   - public_holiday: true
     date: '2020-08-20'
-    names: 
+    names:
       en: Hijri New Year
-      ar: Hijri New Year,
+      ar: Hijri New Year
   - public_holiday: true
     date: '2020-10-29'
-    names: 
+    names:
       en: Birthday of Prophet Muhammad
-      ar: Birthday of Prophet Muhammad,
+      ar: Birthday of Prophet Muhammad
   - public_holiday: true
     date: '2020-11-18'
-    names: 
+    names:
       en: National Day
-      ar: National Day,
+      ar: National Day
   - public_holiday: true
     date: '2020-11-19'
-    names: 
+    names:
       en: Sultan's Birthday
       ar: Sultan's Birthday

--- a/conf/tw/taiwan01.yml
+++ b/conf/tw/taiwan01.yml
@@ -80,688 +80,688 @@ years:
   '2019':
   - public_holiday: true
     date: '2019-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2019-02-04'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2019-02-05'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2019-02-06'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2019-02-07'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2019-02-08'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2019-02-09'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2019-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2019-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2019-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2019-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2019-06-07'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2019-09-13'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2019-10-10'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2020':
   - public_holiday: true
     date: '2020-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2020-01-24'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2020-01-25'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2020-01-26'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2020-01-27'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2020-01-28'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2020-01-29'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2020-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2020-04-03'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2020-04-04'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2020-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2020-06-25'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2020-10-01'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2020-10-09'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2021':
   - public_holiday: true
     date: '2021-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2021-02-11'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2021-02-12'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2021-02-13'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2021-02-14'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2021-02-15'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2021-02-16'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2021-03-01'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2021-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2021-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2021-04-30'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2021-06-14'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2021-09-21'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2021-10-11'
-    names: 
-      en: National Day/Double Tenth Day,
+    names:
+      en: National Day/Double Tenth Day
   - public_holiday: true
     date: '2021-12-31'
-    names: 
+    names:
       en: Republic/New Year's Day observed
   '2022':
   - public_holiday: true
     date: '2022-01-31'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2022-02-01'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2022-02-02'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2022-02-03'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2022-02-04'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2022-02-05'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2022-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2022-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2022-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2022-05-02'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2022-06-03'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2022-09-10'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2022-10-10'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2023':
   - public_holiday: true
     date: '2023-01-02'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2023-01-21'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2023-01-22'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2023-01-23'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2023-01-24'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2023-01-25'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2023-01-26'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2023-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2023-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2023-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2023-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2023-06-22'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2023-09-29'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2023-10-10'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2024':
   - public_holiday: true
     date: '2024-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2024-02-09'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2024-02-10'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2024-02-11'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2024-02-12'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2024-02-13'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2024-02-14'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2024-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2024-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2024-04-04'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2024-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2024-06-10'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2024-09-17'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2024-10-10'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2025':
   - public_holiday: true
     date: '2025-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2025-01-28'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2025-01-29'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2025-01-30'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2025-01-31'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2025-02-01'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2025-02-02'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2025-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2025-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2025-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2025-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2025-05-31'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2025-10-06'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2025-10-10'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2026':
   - public_holiday: true
     date: '2026-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2026-02-16'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2026-02-17'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2026-02-18'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2026-02-19'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2026-02-20'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2026-02-21'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2026-02-27'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2026-04-03'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2026-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2026-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2026-06-19'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2026-09-25'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2026-10-09'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2027':
   - public_holiday: true
     date: '2027-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2027-02-05'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2027-02-06'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2027-02-07'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2027-02-08'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2027-02-09'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2027-02-10'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2027-03-01'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2027-04-05'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2027-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2027-04-30'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2027-06-09'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2027-09-15'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2027-10-11'
-    names: 
-      en: National Day/Double Tenth Day,
+    names:
+      en: National Day/Double Tenth Day
   - public_holiday: true
     date: '2027-12-31'
-    names: 
+    names:
       en: Republic/New Year's Day observed
   '2028':
   - public_holiday: true
     date: '2028-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2028-01-25'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2028-01-26'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2028-01-27'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2028-01-28'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2028-01-29'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2028-01-30'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2028-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2028-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2028-04-04'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2028-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2028-05-28'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2028-10-03'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2028-10-10'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2029':
   - public_holiday: true
     date: '2029-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2029-02-12'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2029-02-13'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2029-02-14'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2029-02-15'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2029-02-16'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2029-02-17'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2029-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2029-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2029-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2029-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2029-06-16'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2029-09-22'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2029-10-10'
-    names: 
+    names:
       en: National Day/Double Tenth Day
   '2030':
   - public_holiday: true
     date: '2030-01-01'
-    names: 
-      en: Republic/New Year's Day,
+    names:
+      en: Republic/New Year's Day
   - public_holiday: true
     date: '2030-02-02'
-    names: 
-      en: Chinese New Year's Eve,
+    names:
+      en: Chinese New Year's Eve
   - public_holiday: true
     date: '2030-02-03'
-    names: 
-      en: Chinese New Year's Day,
+    names:
+      en: Chinese New Year's Day
   - public_holiday: true
     date: '2030-02-04'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2030-02-05'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2030-02-06'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2030-02-07'
-    names: 
-      en: Chinese New Year Holiday,
+    names:
+      en: Chinese New Year Holiday
   - public_holiday: true
     date: '2030-02-28'
-    names: 
-      en: 228 Memorial Day,
+    names:
+      en: 228 Memorial Day
   - public_holiday: true
     date: '2030-04-04'
-    names: 
-      en: Children's Day,
+    names:
+      en: Children's Day
   - public_holiday: true
     date: '2030-04-05'
-    names: 
-      en: Tomb Sweeping Day,
+    names:
+      en: Tomb Sweeping Day
   - public_holiday: true
     date: '2030-05-01'
-    names: 
-      en: Labour Day,
+    names:
+      en: Labour Day
   - public_holiday: true
     date: '2030-06-05'
-    names: 
-      en: Dragon Boat Festival,
+    names:
+      en: Dragon Boat Festival
   - public_holiday: true
     date: '2030-09-12'
-    names: 
-      en: Mid-Autumn Festival,
+    names:
+      en: Mid-Autumn Festival
   - public_holiday: true
     date: '2030-10-10'
-    names: 
+    names:
       en: National Day/Double Tenth Day

--- a/conf/us/united_states07.yml
+++ b/conf/us/united_states07.yml
@@ -17,7 +17,7 @@ years:
   - public_holiday: true
     date: '2011-04-22'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2011-05-30'
     names:
@@ -66,7 +66,7 @@ years:
   - public_holiday: true
     date: '2012-04-06'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2012-05-28'
     names:
@@ -115,7 +115,7 @@ years:
   - public_holiday: true
     date: '2013-03-29'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2013-05-27'
     names:
@@ -164,7 +164,7 @@ years:
   - public_holiday: true
     date: '2014-04-18'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2014-05-26'
     names:
@@ -213,7 +213,7 @@ years:
   - public_holiday: true
     date: '2015-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2015-05-25'
     names:
@@ -262,7 +262,7 @@ years:
   - public_holiday: true
     date: '2016-03-25'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2016-05-30'
     names:
@@ -311,7 +311,7 @@ years:
   - public_holiday: true
     date: '2017-04-14'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2017-05-29'
     names:
@@ -360,7 +360,7 @@ years:
   - public_holiday: true
     date: '2018-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2018-05-28'
     names:
@@ -409,7 +409,7 @@ years:
   - public_holiday: true
     date: '2019-04-19'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2019-05-27'
     names:
@@ -458,7 +458,7 @@ years:
   - public_holiday: true
     date: '2020-04-10'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2020-05-25'
     names:
@@ -507,7 +507,7 @@ years:
   - public_holiday: true
     date: '2021-04-02'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2021-05-31'
     names:
@@ -556,7 +556,7 @@ years:
   - public_holiday: true
     date: '2022-04-15'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2022-05-30'
     names:
@@ -605,7 +605,7 @@ years:
   - public_holiday: true
     date: '2023-04-07'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2023-05-29'
     names:
@@ -654,7 +654,7 @@ years:
   - public_holiday: true
     date: '2024-03-29'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2024-05-27'
     names:
@@ -703,7 +703,7 @@ years:
   - public_holiday: true
     date: '2025-04-18'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2025-05-26'
     names:
@@ -752,7 +752,7 @@ years:
   - public_holiday: true
     date: '2026-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2026-05-25'
     names:
@@ -801,7 +801,7 @@ years:
   - public_holiday: true
     date: '2027-03-26'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2027-05-31'
     names:
@@ -850,7 +850,7 @@ years:
   - public_holiday: true
     date: '2028-04-14'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2028-05-29'
     names:
@@ -899,7 +899,7 @@ years:
   - public_holiday: true
     date: '2029-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2029-05-28'
     names:
@@ -948,7 +948,7 @@ years:
   - public_holiday: true
     date: '2030-04-19'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2030-05-27'
     names:
@@ -997,7 +997,7 @@ years:
   - public_holiday: true
     date: '2031-04-11'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2031-05-26'
     names:
@@ -1046,7 +1046,7 @@ years:
   - public_holiday: true
     date: '2032-03-26'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2032-05-31'
     names:
@@ -1095,7 +1095,7 @@ years:
   - public_holiday: true
     date: '2033-04-15'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2033-05-30'
     names:
@@ -1144,7 +1144,7 @@ years:
   - public_holiday: true
     date: '2034-04-07'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2034-05-29'
     names:
@@ -1193,7 +1193,7 @@ years:
   - public_holiday: true
     date: '2035-03-23'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2035-05-28'
     names:
@@ -1242,7 +1242,7 @@ years:
   - public_holiday: true
     date: '2036-04-11'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2036-05-26'
     names:
@@ -1291,7 +1291,7 @@ years:
   - public_holiday: true
     date: '2037-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2037-05-25'
     names:
@@ -1340,7 +1340,7 @@ years:
   - public_holiday: true
     date: '2038-04-23'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2038-05-31'
     names:
@@ -1389,7 +1389,7 @@ years:
   - public_holiday: true
     date: '2039-04-08'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2039-05-30'
     names:
@@ -1438,7 +1438,7 @@ years:
   - public_holiday: true
     date: '2040-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2040-05-28'
     names:

--- a/conf/us/united_states08.yml
+++ b/conf/us/united_states08.yml
@@ -9,7 +9,7 @@ years:
   - public_holiday: true
     date: '2011-04-22'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2011-05-30'
     names:
@@ -50,7 +50,7 @@ years:
   - public_holiday: true
     date: '2012-04-06'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2012-05-28'
     names:
@@ -99,7 +99,7 @@ years:
   - public_holiday: true
     date: '2013-03-29'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2013-05-27'
     names:
@@ -140,7 +140,7 @@ years:
   - public_holiday: true
     date: '2014-04-18'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2014-05-26'
     names:
@@ -189,7 +189,7 @@ years:
   - public_holiday: true
     date: '2015-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2015-05-25'
     names:
@@ -230,7 +230,7 @@ years:
   - public_holiday: true
     date: '2016-03-25'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2016-05-30'
     names:
@@ -279,7 +279,7 @@ years:
   - public_holiday: true
     date: '2017-04-14'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2017-05-29'
     names:
@@ -320,7 +320,7 @@ years:
   - public_holiday: true
     date: '2018-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2018-05-28'
     names:
@@ -369,7 +369,7 @@ years:
   - public_holiday: true
     date: '2019-04-19'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2019-05-27'
     names:
@@ -410,7 +410,7 @@ years:
   - public_holiday: true
     date: '2020-04-10'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2020-05-25'
     names:
@@ -459,7 +459,7 @@ years:
   - public_holiday: true
     date: '2021-04-02'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2021-05-31'
     names:
@@ -500,7 +500,7 @@ years:
   - public_holiday: true
     date: '2022-04-15'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2022-05-30'
     names:
@@ -549,7 +549,7 @@ years:
   - public_holiday: true
     date: '2023-04-07'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2023-05-29'
     names:
@@ -590,7 +590,7 @@ years:
   - public_holiday: true
     date: '2024-03-29'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2024-05-27'
     names:
@@ -639,7 +639,7 @@ years:
   - public_holiday: true
     date: '2025-04-18'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2025-05-26'
     names:
@@ -680,7 +680,7 @@ years:
   - public_holiday: true
     date: '2026-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2026-05-25'
     names:
@@ -729,7 +729,7 @@ years:
   - public_holiday: true
     date: '2027-03-26'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2027-05-31'
     names:
@@ -770,7 +770,7 @@ years:
   - public_holiday: true
     date: '2028-04-14'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2028-05-29'
     names:
@@ -819,7 +819,7 @@ years:
   - public_holiday: true
     date: '2029-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2029-05-28'
     names:
@@ -860,7 +860,7 @@ years:
   - public_holiday: true
     date: '2030-04-19'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2030-05-27'
     names:
@@ -909,7 +909,7 @@ years:
   - public_holiday: true
     date: '2031-04-11'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2031-05-26'
     names:
@@ -950,7 +950,7 @@ years:
   - public_holiday: true
     date: '2032-03-26'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2032-05-31'
     names:
@@ -999,7 +999,7 @@ years:
   - public_holiday: true
     date: '2033-04-15'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2033-05-30'
     names:
@@ -1040,7 +1040,7 @@ years:
   - public_holiday: true
     date: '2034-04-07'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2034-05-29'
     names:
@@ -1089,7 +1089,7 @@ years:
   - public_holiday: true
     date: '2035-03-23'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2035-05-28'
     names:
@@ -1130,7 +1130,7 @@ years:
   - public_holiday: true
     date: '2036-04-11'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2036-05-26'
     names:
@@ -1179,7 +1179,7 @@ years:
   - public_holiday: true
     date: '2037-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2037-05-25'
     names:
@@ -1220,7 +1220,7 @@ years:
   - public_holiday: true
     date: '2038-04-23'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2038-05-31'
     names:
@@ -1269,7 +1269,7 @@ years:
   - public_holiday: true
     date: '2039-04-08'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2039-05-30'
     names:
@@ -1310,7 +1310,7 @@ years:
   - public_holiday: true
     date: '2040-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2040-05-28'
     names:

--- a/conf/us/united_states12.yml
+++ b/conf/us/united_states12.yml
@@ -17,7 +17,7 @@ years:
   - public_holiday: true
     date: '2011-04-22'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2011-05-30'
     names:
@@ -70,7 +70,7 @@ years:
   - public_holiday: true
     date: '2012-04-06'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2012-05-28'
     names:
@@ -127,7 +127,7 @@ years:
   - public_holiday: true
     date: '2013-03-29'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2013-05-27'
     names:
@@ -180,7 +180,7 @@ years:
   - public_holiday: true
     date: '2014-04-18'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2014-05-26'
     names:
@@ -237,7 +237,7 @@ years:
   - public_holiday: true
     date: '2015-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2015-05-25'
     names:
@@ -290,7 +290,7 @@ years:
   - public_holiday: true
     date: '2016-03-25'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2016-05-30'
     names:
@@ -347,7 +347,7 @@ years:
   - public_holiday: true
     date: '2017-04-14'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2017-05-29'
     names:
@@ -400,7 +400,7 @@ years:
   - public_holiday: true
     date: '2018-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2018-05-28'
     names:
@@ -457,7 +457,7 @@ years:
   - public_holiday: true
     date: '2019-04-19'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2019-05-27'
     names:
@@ -510,7 +510,7 @@ years:
   - public_holiday: true
     date: '2020-04-10'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2020-05-25'
     names:
@@ -567,7 +567,7 @@ years:
   - public_holiday: true
     date: '2021-04-02'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2021-05-31'
     names:
@@ -620,7 +620,7 @@ years:
   - public_holiday: true
     date: '2022-04-15'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2022-05-30'
     names:
@@ -677,7 +677,7 @@ years:
   - public_holiday: true
     date: '2023-04-07'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2023-05-29'
     names:
@@ -730,7 +730,7 @@ years:
   - public_holiday: true
     date: '2024-03-29'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2024-05-27'
     names:
@@ -787,7 +787,7 @@ years:
   - public_holiday: true
     date: '2025-04-18'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2025-05-26'
     names:
@@ -840,7 +840,7 @@ years:
   - public_holiday: true
     date: '2026-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2026-05-25'
     names:
@@ -897,7 +897,7 @@ years:
   - public_holiday: true
     date: '2027-03-26'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2027-05-31'
     names:
@@ -950,7 +950,7 @@ years:
   - public_holiday: true
     date: '2028-04-14'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2028-05-29'
     names:
@@ -1007,7 +1007,7 @@ years:
   - public_holiday: true
     date: '2029-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2029-05-28'
     names:
@@ -1060,7 +1060,7 @@ years:
   - public_holiday: true
     date: '2030-04-19'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2030-05-27'
     names:
@@ -1117,7 +1117,7 @@ years:
   - public_holiday: true
     date: '2031-04-11'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2031-05-26'
     names:
@@ -1170,7 +1170,7 @@ years:
   - public_holiday: true
     date: '2032-03-26'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2032-05-31'
     names:
@@ -1227,7 +1227,7 @@ years:
   - public_holiday: true
     date: '2033-04-15'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2033-05-30'
     names:
@@ -1280,7 +1280,7 @@ years:
   - public_holiday: true
     date: '2034-04-07'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2034-05-29'
     names:
@@ -1333,7 +1333,7 @@ years:
   - public_holiday: true
     date: '2035-03-23'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2035-03-26'
     names:
@@ -1390,7 +1390,7 @@ years:
   - public_holiday: true
     date: '2036-04-11'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2036-05-26'
     names:
@@ -1447,7 +1447,7 @@ years:
   - public_holiday: true
     date: '2037-04-03'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2037-05-25'
     names:
@@ -1500,7 +1500,7 @@ years:
   - public_holiday: true
     date: '2038-04-23'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2038-05-31'
     names:
@@ -1557,7 +1557,7 @@ years:
   - public_holiday: true
     date: '2039-04-08'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2039-05-30'
     names:
@@ -1610,7 +1610,7 @@ years:
   - public_holiday: true
     date: '2040-03-30'
     names:
-      en: 'Good Friday '
+      en: 'Good Friday'
   - public_holiday: true
     date: '2040-05-28'
     names:

--- a/tests/public_holidays_test.rb
+++ b/tests/public_holidays_test.rb
@@ -46,4 +46,28 @@ describe 'Public Holidays' do
       end
     end
   end
+
+  describe 'must have clean names' do
+    Dir.chdir(TestUtils.config_directory) do
+      Dir.glob('*/*.yml').each do |region_file|
+        region_data = YAML.safe_load(File.read(region_file))
+
+        region_name = region_data['name']
+
+        region_data['years'].values.each do |holidays|
+          holidays.each do |holiday|
+            holiday['names'].values.each do |name|
+              it "public holiday #{name} does not end with a comma" do
+                name.wont_match(/,$/)
+              end
+
+              it "public holiday #{name} does not end in whitespace" do
+                name.wont_match(/\s$/)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
A bunch of trailing commas and trailing whitespace got into the names of
our holidays.

Added tests to catch these bugs.