### PR TITLE
Christmas Eve is not a public holiday

### DIFF
--- a/conf/by/belarus01.yml
+++ b/conf/by/belarus01.yml
@@ -144,7 +144,7 @@ years:
     names:
       en: October Revolution Day
       be: October Revolution Day
-  - public_holiday: true
+  - public_holiday: false
     date: '2019-12-24'
     names:
       en: Christmas Eve


### PR DESCRIPTION
Checked Charlie to make sure that national holidays that are `public_holiday: false` are skipped. In the future we can put these in the calendar but ensure they're not treated like a holiday.