### PR TITLE
Remove Easter Monday from Scotland

### DIFF
--- a/conf/gb/united_kingdom03.yml
+++ b/conf/gb/united_kingdom03.yml
@@ -11,10 +11,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2011-04-25'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2011-04-29'
     names:
       en: Royal Wedding Day
@@ -47,10 +43,6 @@ years:
     date: '2012-01-03'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2012-04-09'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2012-05-07'
     names:
@@ -85,10 +77,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2013-04-01'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2013-05-06'
     names:
       en: May Day Bank Holiday
@@ -117,10 +105,6 @@ years:
     date: '2014-01-02'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2014-04-21'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2014-05-05'
     names:
@@ -151,10 +135,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2015-04-06'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2015-05-04'
     names:
       en: May Day Bank Holiday
@@ -183,10 +163,6 @@ years:
     date: '2016-01-04'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2016-03-28'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2016-05-02'
     names:
@@ -357,10 +333,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2021-04-05'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2021-05-03'
     names:
       en: May Day Bank Holiday
@@ -389,10 +361,6 @@ years:
     date: '2022-01-04'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2022-04-18'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2022-05-02'
     names:
@@ -423,10 +391,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2023-04-10'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2023-05-01'
     names:
       en: May Day Bank Holiday
@@ -455,10 +419,6 @@ years:
     date: '2024-01-02'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2024-04-01'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2024-05-06'
     names:
@@ -489,10 +449,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2025-04-21'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2025-05-05'
     names:
       en: May Day Bank Holiday
@@ -521,10 +477,6 @@ years:
     date: '2026-01-02'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2026-04-06'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2026-05-04'
     names:
@@ -555,10 +507,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2027-03-29'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2027-05-03'
     names:
       en: May Day Bank Holiday
@@ -587,10 +535,6 @@ years:
     date: '2028-01-04'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2028-04-17'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2028-05-01'
     names:
@@ -621,10 +565,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2029-04-02'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2029-05-07'
     names:
       en: May Day Bank Holiday
@@ -653,10 +593,6 @@ years:
     date: '2030-01-02'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2030-04-22'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2030-05-06'
     names:
@@ -687,10 +623,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2031-04-14'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2031-05-05'
     names:
       en: May Day Bank Holiday
@@ -719,10 +651,6 @@ years:
     date: '2032-01-02'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2032-03-29'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2032-05-03'
     names:
@@ -753,10 +681,6 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2033-04-18'
-    names:
-      en: Easter Monday
-  - public_holiday: true
     date: '2033-05-02'
     names:
       en: May Day Bank Holiday
@@ -785,10 +709,6 @@ years:
     date: '2034-01-03'
     names:
       en: New Year's Day
-  - public_holiday: true
-    date: '2034-04-10'
-    names:
-      en: Easter Monday
   - public_holiday: true
     date: '2034-05-01'
     names:


### PR DESCRIPTION
Easter Monday is not a public holiday in Scotland.
Source: https://www.mygov.scot/scotland-bank-holidays/