### PR TITLE
Update denmark01.yml

### DIFF
--- a/conf/dk/denmark01.yml
+++ b/conf/dk/denmark01.yml
@@ -647,11 +647,6 @@ years:
       en: Constitution Day
       da: Grundlovsdag
   - public_holiday: true
-    date: '2020-12-24'
-    names:
-      en: Christmas Eve
-      da: Juleaften
-  - public_holiday: true
     date: '2020-12-25'
     names:
       en: Christmas Day
@@ -712,11 +707,6 @@ years:
     names:
       en: Constitution Day
       da: Grundlovsdag
-  - public_holiday: true
-    date: '2021-12-24'
-    names:
-      en: Christmas Eve
-      da: Juleaften
   - public_holiday: true
     date: '2021-12-25'
     names:
@@ -779,11 +769,6 @@ years:
       en: Whit Monday
       da: 2. Pinsedag
   - public_holiday: true
-    date: '2022-12-24'
-    names:
-      en: Christmas Eve
-      da: Juleaften
-  - public_holiday: true
     date: '2022-12-25'
     names:
       en: Christmas Day
@@ -844,11 +829,6 @@ years:
     names:
       en: Constitution Day
       da: Grundlovsdag
-  - public_holiday: true
-    date: '2023-12-24'
-    names:
-      en: Christmas Eve
-      da: Juleaften
   - public_holiday: true
     date: '2023-12-25'
     names:
@@ -911,11 +891,6 @@ years:
       en: Constitution Day
       da: Grundlovsdag
   - public_holiday: true
-    date: '2024-12-24'
-    names:
-      en: Christmas Eve
-      da: Juleaften
-  - public_holiday: true
     date: '2024-12-25'
     names:
       en: Christmas Day
@@ -976,11 +951,6 @@ years:
     names:
       en: Whit Monday
       da: 2. Pinsedag
-  - public_holiday: true
-    date: '2025-12-24'
-    names:
-      en: Christmas Eve
-      da: Juleaften
   - public_holiday: true
     date: '2025-12-25'
     names:


### PR DESCRIPTION
Removed Juleaften, not a national holiday as per:

https://www.detfagligehus.dk/spoergsmaal-og-svar/ferie-og-fridage/er-juleaftensdag-og-nytaarsaften-fridage/#:~:text=Juleaftensdag%20den%2024.,m%C3%B8de%20p%C3%A5%20arbejde%20som%20normalt