### PR TITLE
add good friday public holiday to Nothern Ireland

### DIFF
--- a/conf/gb/united_kingdom04.yml
+++ b/conf/gb/united_kingdom04.yml
@@ -450,6 +450,10 @@ years:
     names:
       en: St. Patrick's Day
   - public_holiday: true
+    date: '2022-04-15'
+    names:
+      en: Good Friday
+  - public_holiday: true
     date: '2022-04-18'
     names:
       en: Easter Monday


### PR DESCRIPTION
Add Good Friday public holiday to Nothern Ireland following [this request](https://charliehr.slack.com/archives/C40MYMJ02/p1643709593269759)