### PR TITLE
Add King Charles III Coronation holiday to UK

### DIFF
--- a/conf/gb/united_kingdom01.yml
+++ b/conf/gb/united_kingdom01.yml
@@ -431,6 +431,10 @@ years:
     names:
       en: May Day Bank Holiday
   - public_holiday: true
+    date: '2023-05-08'
+    names:
+      en: King Charles III Coronation Holiday
+  - public_holiday: true
     date: '2023-05-29'
     names:
       en: Spring Bank Holiday

--- a/conf/gb/united_kingdom02.yml
+++ b/conf/gb/united_kingdom02.yml
@@ -431,6 +431,10 @@ years:
     names:
       en: May Day Bank Holiday
   - public_holiday: true
+    date: '2023-05-08'
+    names:
+      en: King Charles III Coronation Holiday
+  - public_holiday: true
     date: '2023-05-29'
     names:
       en: Spring Bank Holiday

--- a/conf/gb/united_kingdom03.yml
+++ b/conf/gb/united_kingdom03.yml
@@ -447,6 +447,10 @@ years:
     names:
       en: May Day Bank Holiday
   - public_holiday: true
+    date: '2023-05-08'
+    names:
+      en: King Charles III Coronation Holiday
+  - public_holiday: true
     date: '2023-05-29'
     names:
       en: Spring Bank Holiday

--- a/conf/gb/united_kingdom04.yml
+++ b/conf/gb/united_kingdom04.yml
@@ -507,6 +507,10 @@ years:
     names:
       en: May Day Bank Holiday
   - public_holiday: true
+    date: '2023-05-08'
+    names:
+      en: King Charles III Coronation Holiday
+  - public_holiday: true
     date: '2023-05-29'
     names:
       en: Spring Bank Holiday

--- a/conf/gb/united_kingdom05.yml
+++ b/conf/gb/united_kingdom05.yml
@@ -431,6 +431,10 @@ years:
     names:
       en: May Day Bank Holiday
   - public_holiday: true
+    date: '2023-05-08'
+    names:
+      en: King Charles III Coronation Holiday
+  - public_holiday: true
     date: '2023-05-29'
     names:
       en: Spring Bank Holiday

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,6 +1,6 @@
 # Coverage
 
-Last updated 2022-04-11.
+Last updated 2022-11-08.
 
 | Flag | Country | Region | Latest Public Holidays Year | Known Public Holidays | Latest Non-public Holidays Year | Known Non-public Holidays |
 | ---- | ------- | ------ | --------------------------- | --------------------- | ------------------------------- | ------------------------- |


### PR DESCRIPTION
Adds Bank holidays to UK for the coronation of King Charles III Coronation.