### PR TITLE
Update countries gem to 5.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,12 +4,9 @@ GEM
     ansi (1.5.0)
     ast (2.4.0)
     builder (3.2.3)
-    countries (3.0.0)
-      i18n_data (~> 0.8.0)
-      sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
+    countries (5.2.0)
+      unaccent (~> 0.3)
     date (2.0.0)
-    i18n_data (0.8.0)
     jaro_winkler (1.5.2)
     minitest (5.11.3)
     minitest-reporters (1.3.6)
@@ -32,9 +29,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
     ruby-progressbar (1.10.0)
-    sixarm_ruby_unaccent (1.2.0)
+    unaccent (0.4.0)
     unicode-display_width (1.5.0)
-    unicode_utils (1.4.0)
 
 PLATFORMS
   ruby

--- a/bin/build_docs.rb
+++ b/bin/build_docs.rb
@@ -59,7 +59,7 @@ class CoverageDoc
       table << table.first.map { |s| s.gsub(/./, '-') }
 
       Dir.chdir(config_directory) do
-        ISO3166::Country.all.sort_by(&:name).map do |country|
+        ISO3166::Country.all.sort_by(&:iso_short_name).map do |country|
           country_rows(country).each do |row|
             table << row
           end
@@ -91,7 +91,7 @@ class CoverageDoc
 
           [
             country.emoji_flag,
-            country.name,
+            country.iso_short_name,
             region_name,
             public_holidays_latest_year || '-',
             public_holidays_latest_year ? region_years[public_holidays_latest_year].count : '-',
@@ -102,7 +102,7 @@ class CoverageDoc
       end
     else
       [
-        [country.emoji_flag, country.name, 'No Data', '-', '-', '-', '-']
+        [country.emoji_flag, country.iso_short_name, 'No Data', '-', '-', '-', '-']
       ]
     end
   end

--- a/bin/danger.rb
+++ b/bin/danger.rb
@@ -12,7 +12,7 @@ class Danger
 
   def run
     Dir.chdir(config_directory) do
-      ISO3166::Country.all.sort_by(&:name).map do |country|
+      ISO3166::Country.all.sort_by(&:iso_short_name).map do |country|
         check(country)
       end
     end
@@ -36,7 +36,7 @@ class Danger
           end.map(&:to_i).compact.max
 
           if public_holidays_latest_year <= Date.today.year
-            puts "#{country.name}\t#{region_name}\t#{public_holidays_latest_year}"
+            puts "#{country.iso_short_name}\t#{region_name}\t#{public_holidays_latest_year}"
           end
         end
       end

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -81,7 +81,7 @@ Last updated 2022-11-08.
 | 🇨🇺 | Cuba | Cuba (all) | 2021 | 13 | - | - |
 | 🇨🇼 | Curaçao | No Data | - | - | - | - |
 | 🇨🇾 | Cyprus | Cyprus | 2021 | 13 | - | - |
-| 🇨🇿 | Czech Republic | Czech Republic (all) | 2040 | 13 | - | - |
+| 🇨🇿 | Czechia | Czech Republic (all) | 2040 | 13 | - | - |
 | 🇨🇮 | Côte d'Ivoire | No Data | - | - | - | - |
 | 🇩🇰 | Denmark | Denmark (all) | 2040 | 13 | - | - |
 | 🇩🇯 | Djibouti | No Data | - | - | - | - |
@@ -93,6 +93,7 @@ Last updated 2022-11-08.
 | 🇬🇶 | Equatorial Guinea | No Data | - | - | - | - |
 | 🇪🇷 | Eritrea | No Data | - | - | - | - |
 | 🇪🇪 | Estonia | Estonia (all) | 2040 | 12 | - | - |
+| 🇸🇿 | Eswatini | No Data | - | - | - | - |
 | 🇪🇹 | Ethiopia | Ethiopia (all) | 2021 | 13 | - | - |
 | 🇫🇰 | Falkland Islands (Malvinas) | No Data | - | - | - | - |
 | 🇫🇴 | Faroe Islands | No Data | - | - | - | - |
@@ -171,7 +172,6 @@ Last updated 2022-11-08.
 | 🇱🇹 | Lithuania | Lithuania (all) | 2040 | 15 | - | - |
 | 🇱🇺 | Luxembourg | Luxembourg (all) | 2040 | 10 | - | - |
 | 🇲🇴 | Macao | No Data | - | - | - | - |
-| 🇲🇰 | Macedonia (the former Yugoslav Republic of) | Macedonia, Republic of (all) | 2021 | 11 | - | - |
 | 🇲🇬 | Madagascar | No Data | - | - | - | - |
 | 🇲🇼 | Malawi | No Data | - | - | - | - |
 | 🇲🇾 | Malaysia | Malaysia (all) | 2022 | 6 | - | - |
@@ -215,6 +215,7 @@ Last updated 2022-11-08.
 | 🇳🇬 | Nigeria | Nigeria (all) | 2022 | 8 | - | - |
 | 🇳🇺 | Niue | No Data | - | - | - | - |
 | 🇳🇫 | Norfolk Island | No Data | - | - | - | - |
+| 🇲🇰 | North Macedonia | Macedonia, Republic of (all) | 2021 | 11 | - | - |
 | 🇲🇵 | Northern Mariana Islands | No Data | - | - | - | - |
 | 🇳🇴 | Norway | Norway (all) | 2040 | 12 | - | - |
 | 🇴🇲 | Oman | Oman | 2021 | 13 | - | - |
@@ -273,7 +274,6 @@ Last updated 2022-11-08.
 | 🇸🇩 | Sudan | No Data | - | - | - | - |
 | 🇸🇷 | Suriname | No Data | - | - | - | - |
 | 🇸🇯 | Svalbard and Jan Mayen | No Data | - | - | - | - |
-| 🇸🇿 | Swaziland | No Data | - | - | - | - |
 | 🇸🇪 | Sweden | Sweden (all) | 2040 | 16 | - | - |
 | 🇨🇭 | Switzerland | Canton de Vaud | 2022 | 9 | - | - |
 | 🇨🇭 | Switzerland | Geneva | 2022 | 9 | - | - |
@@ -290,10 +290,10 @@ Last updated 2022-11-08.
 | 🇹🇴 | Tonga | No Data | - | - | - | - |
 | 🇹🇹 | Trinidad and Tobago | No Data | - | - | - | - |
 | 🇹🇳 | Tunisia | Tunisia (all) | 2021 | 15 | - | - |
-| 🇹🇷 | Turkey | Turkey (all) | 2021 | 15 | - | - |
 | 🇹🇲 | Turkmenistan | No Data | - | - | - | - |
 | 🇹🇨 | Turks and Caicos Islands | No Data | - | - | - | - |
 | 🇹🇻 | Tuvalu | No Data | - | - | - | - |
+| 🇹🇷 | Türkiye | Turkey (all) | 2021 | 15 | - | - |
 | 🇺🇬 | Uganda | No Data | - | - | - | - |
 | 🇺🇦 | Ukraine | Ukraine (all) | 2040 | 13 | - | - |
 | 🇦🇪 | United Arab Emirates | Dubai (all) | 2021 | 15 | - | - |


### PR DESCRIPTION
This updates a few countries names including Eswatini, North Macedonia and Czechia.

It also deprecates the 'name' field which has been updated to iso_short_name.

More information [here](https://github.com/countries/countries/blob/master/UPGRADE.md)