### PR TITLE
Add St Andrew's day

### DIFF
--- a/conf/gb/united_kingdom03.yml
+++ b/conf/gb/united_kingdom03.yml
@@ -439,9 +439,9 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2023-04-10'
+    date: '2023-04-07'
     names:
-      en: Easter Monday
+      en: Good Friday
   - public_holiday: true
     date: '2023-05-01'
     names:
@@ -458,6 +458,10 @@ years:
     date: '2023-08-07'
     names:
       en: Late Summer Bank Holiday
+  - public_holiday: true
+    date: '2023-11-30'
+    names:
+      en: St Andrew's Day
   - public_holiday: true
     date: '2023-12-25'
     names:
@@ -476,9 +480,9 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2024-04-01'
+    date: '2024-03-29'
     names:
-      en: Easter Monday
+      en: Good Friday
   - public_holiday: true
     date: '2024-05-06'
     names:
@@ -491,6 +495,10 @@ years:
     date: '2024-08-05'
     names:
       en: Late Summer Bank Holiday
+  - public_holiday: true
+    date: '2024-11-30'
+    names:
+      en: St Andrew's Day
   - public_holiday: true
     date: '2024-12-25'
     names:
@@ -509,9 +517,9 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2025-04-21'
+    date: '2025-04-18'
     names:
-      en: Easter Monday
+      en: Good Friday
   - public_holiday: true
     date: '2025-05-05'
     names:
@@ -524,6 +532,10 @@ years:
     date: '2025-08-04'
     names:
       en: Late Summer Bank Holiday
+  - public_holiday: true
+    date: '2025-11-30'
+    names:
+      en: St Andrew's Day
   - public_holiday: true
     date: '2025-12-25'
     names:
@@ -542,9 +554,9 @@ years:
     names:
       en: New Year's Day
   - public_holiday: true
-    date: '2026-04-06'
+    date: '2026-04-03'
     names:
-      en: Easter Monday
+      en: Good Friday
   - public_holiday: true
     date: '2026-05-04'
     names:
@@ -557,6 +569,10 @@ years:
     date: '2026-08-03'
     names:
       en: Late Summer Bank Holiday
+  - public_holiday: true
+    date: '2026-11-30'
+    names:
+      en: St Andrew's Day
   - public_holiday: true
     date: '2026-12-25'
     names:
@@ -590,6 +606,10 @@ years:
     date: '2027-08-02'
     names:
       en: Late Summer Bank Holiday
+  - public_holiday: true
+    date: '2027-11-30'
+    names:
+      en: St Andrew's Day
   - public_holiday: true
     date: '2027-12-27'
     names:

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,6 +1,6 @@
 # Coverage
 
-Last updated 2022-11-23.
+Last updated 2023-04-06.
 
 | Flag | Country | Region | Latest Public Holidays Year | Known Public Holidays | Latest Non-public Holidays Year | Known Non-public Holidays |
 | ---- | ------- | ------ | --------------------------- | --------------------- | ------------------------------- | ------------------------- |
@@ -300,7 +300,7 @@ Last updated 2022-11-23.
 | 🇦🇪 | United Arab Emirates | United Arab Emirates (all) | 2021 | 15 | - | - |
 | 🇬🇧 | United Kingdom of Great Britain and Northern Ireland | England | 2040 | 8 | - | - |
 | 🇬🇧 | United Kingdom of Great Britain and Northern Ireland | Wales | 2040 | 8 | - | - |
-| 🇬🇧 | United Kingdom of Great Britain and Northern Ireland | Scotland (incl. St. Andrew's Day) | 2034 | 8 | - | - |
+| 🇬🇧 | United Kingdom of Great Britain and Northern Ireland | Scotland (incl. St. Andrew's Day) | 2034 | 9 | - | - |
 | 🇬🇧 | United Kingdom of Great Britain and Northern Ireland | Northern Ireland | 2034 | 9 | - | - |
 | 🇬🇧 | United Kingdom of Great Britain and Northern Ireland | Scotland (excl. St. Andrew's Day) | 2034 | 8 | - | - |
 | 🇺🇲 | United States Minor Outlying Islands | No Data | - | - | - | - |


### PR DESCRIPTION
This adds St Andrew's Day to Scotland Inc St Andrew's Day public holidays.

Please note that we only have up to 2027 public holidays available, we these will need to be updated in 4 years time (if we're still using the gem for this)