### PR TITLE
Add Europe Day to Luxembourg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :development, :test do
   gem 'countries'
   gem 'date'
   gem 'minitest'
+  gem 'minitest-fail-fast'
   gem 'minitest-reporters'
   gem 'rake'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,52 +3,60 @@ GEM
   specs:
     ansi (1.5.0)
     ast (2.4.2)
-    builder (3.2.4)
-    countries (5.4.0)
+    builder (3.3.0)
+    countries (7.0.0)
       unaccent (~> 0.3)
-    date (3.3.3)
-    json (2.6.3)
-    minitest (5.18.0)
-    minitest-reporters (1.6.0)
+    date (3.4.1)
+    json (2.10.1)
+    language_server-protocol (3.17.0.4)
+    lint_roller (1.1.0)
+    minitest (5.25.4)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-reporters (1.7.1)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    parallel (1.23.0)
-    parser (3.2.2.1)
+    parallel (1.26.3)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.8.0)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
-    rubocop (1.52.0)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rubocop (1.73.1)
       json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
-      parser (>= 3.2.1.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.38.1)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    strscan (3.1.0)
     unaccent (0.4.0)
-    unicode-display_width (2.4.2)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
   countries
   date
   minitest
+  minitest-fail-fast
   minitest-reporters
   rake
   rubocop
 
 BUNDLED WITH
-   2.1.4
+   2.6.5

--- a/conf/lu/luxembourg01.yml
+++ b/conf/lu/luxembourg01.yml
@@ -742,6 +742,11 @@ years:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
   - public_holiday: true
+    date: '2025-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
+  - public_holiday: true
     date: '2025-05-29'
     names:
       en: Ascension Day
@@ -792,6 +797,11 @@ years:
     names:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
+  - public_holiday: true
+    date: '2026-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
   - public_holiday: true
     date: '2026-05-14'
     names:
@@ -849,6 +859,11 @@ years:
       en: Ascension Day
       fr: Ascension / Christi Himmelfahrt
   - public_holiday: true
+    date: '2027-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
+  - public_holiday: true
     date: '2027-05-17'
     names:
       en: Whit Monday
@@ -894,6 +909,11 @@ years:
     names:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
+  - public_holiday: true
+    date: '2028-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
   - public_holiday: true
     date: '2028-05-25'
     names:
@@ -946,6 +966,11 @@ years:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
   - public_holiday: true
+    date: '2029-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
+  - public_holiday: true
     date: '2029-05-10'
     names:
       en: Ascension Day
@@ -997,6 +1022,11 @@ years:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
   - public_holiday: true
+    date: '2030-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
+  - public_holiday: true
     date: '2030-05-30'
     names:
       en: Ascension Day
@@ -1047,6 +1077,11 @@ years:
     names:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
+  - public_holiday: true
+    date: '2031-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
   - public_holiday: true
     date: '2031-05-22'
     names:
@@ -1104,6 +1139,11 @@ years:
       en: Ascension Day
       fr: Ascension / Christi Himmelfahrt
   - public_holiday: true
+    date: '2032-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
+  - public_holiday: true
     date: '2032-05-17'
     names:
       en: Whit Monday
@@ -1149,6 +1189,11 @@ years:
     names:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
+  - public_holiday: true
+    date: '2033-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
   - public_holiday: true
     date: '2033-05-26'
     names:
@@ -1200,6 +1245,11 @@ years:
     names:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
+  - public_holiday: true
+    date: '2034-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
   - public_holiday: true
     date: '2034-05-18'
     names:
@@ -1257,6 +1307,11 @@ years:
       en: Ascension Day
       fr: Ascension / Christi Himmelfahrt
   - public_holiday: true
+    date: '2035-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
+  - public_holiday: true
     date: '2035-05-14'
     names:
       en: Whit Monday
@@ -1302,6 +1357,11 @@ years:
     names:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
+  - public_holiday: true
+    date: '2036-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
   - public_holiday: true
     date: '2036-05-22'
     names:
@@ -1354,6 +1414,11 @@ years:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
   - public_holiday: true
+    date: '2037-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
+  - public_holiday: true
     date: '2037-05-14'
     names:
       en: Ascension Day
@@ -1404,6 +1469,11 @@ years:
     names:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
+  - public_holiday: true
+    date: '2038-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
   - public_holiday: true
     date: '2038-06-03'
     names:
@@ -1456,6 +1526,11 @@ years:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
   - public_holiday: true
+    date: '2039-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
+  - public_holiday: true
     date: '2039-05-19'
     names:
       en: Ascension Day
@@ -1506,6 +1581,11 @@ years:
     names:
       en: May Day
       fr: "1. Mee / Fête du Travail / Tag der Arbeit"
+  - public_holiday: true
+    date: '2040-05-09'
+    names:
+      en: Europe Day
+      fr: "Journée de l'Europe / Europatag"
   - public_holiday: true
     date: '2040-05-10'
     names:


### PR DESCRIPTION
This adds Europe Day to Luxembourg and also installs the minitest-fail-fast gem to make testing a bit easier.