### PR TITLE
Move St Andrews Day to the Monday

### DIFF
--- a/conf/gb/united_kingdom03.yml
+++ b/conf/gb/united_kingdom03.yml
@@ -533,7 +533,7 @@ years:
     names:
       en: Late Summer Bank Holiday
   - public_holiday: true
-    date: '2025-11-30'
+    date: '2025-12-01'
     names:
       en: St Andrew's Day
   - public_holiday: true


### PR DESCRIPTION
Move St Andrews Day to the Monday

Slack request: https://charliehr.slack.com/archives/C40MYMJ02/p1750157483864739

St Andrew's day falls on the Sunday, so there is a substitute bank holiday on the Monday 1st Dec.