### PR TITLE
Add holiday to New York state holidays

### DIFF
--- a/conf/us/united_states33.yml
+++ b/conf/us/united_states33.yml
@@ -722,6 +722,10 @@ years:
     names:
       en: Juneteenth
   - public_holiday: true
+    date: '2026-07-03'
+    names:
+      en: Independence Day Holiday
+  - public_holiday: true
     date: '2026-07-04'
     names:
       en: Independence Day

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,6 +1,6 @@
 # Coverage
 
-Last updated 2025-11-18.
+Last updated 2026-02-06.
 
 | Flag | Country | Region | Latest Public Holidays Year | Known Public Holidays | Latest Non-public Holidays Year | Known Non-public Holidays |
 | ---- | ------- | ------ | --------------------------- | --------------------- | ------------------------------- | ------------------------- |


### PR DESCRIPTION
In 2026 Independence Day (4th July) will fall on a Saturday. Many states have a holiday in lieu on Friday 3rd July to celebrate. This additional holiday is already in the config for many other US states but is missing from the `united_states33` region, New York. We had a customer based in New York query this, so this commit is adding the holiday in.