### PR TITLE
Add Saxony (DE State) holidays from 2023 to 2040

### DIFF
--- a/conf/de/germany15.yml
+++ b/conf/de/germany15.yml
@@ -235,3 +235,1011 @@ years:
     names:
       en: 2. Weihnachtstag
       de: 2. Weihnachtstag
+  '2023':
+  - public_holiday: true
+    date: '2023-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2023-04-07'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2023-04-10'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2023-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2023-05-18'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2023-05-29'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2023-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2023-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2023-11-22'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2023-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2023-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2024':
+  - public_holiday: true
+    date: '2024-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2024-03-29'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2024-04-01'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2024-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2024-05-09'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2024-05-20'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2024-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2024-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2024-11-20'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2024-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2024-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2025':
+  - public_holiday: true
+    date: '2025-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2025-04-18'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2025-04-21'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2025-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2025-05-29'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2025-06-09'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2025-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2025-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2025-11-19'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2025-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2025-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2026':
+  - public_holiday: true
+    date: '2026-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2026-04-03'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2026-04-06'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2026-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2026-05-14'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2026-05-25'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2026-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2026-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2026-11-18'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2026-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2026-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2027':
+  - public_holiday: true
+    date: '2027-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2027-03-26'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2027-03-29'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2027-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2027-05-06'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2027-05-17'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2027-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2027-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2027-11-17'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2027-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2027-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2028':
+  - public_holiday: true
+    date: '2028-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2028-04-14'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2028-04-17'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2028-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2028-05-25'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2028-06-05'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2028-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2028-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2028-11-22'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2028-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2028-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2029':
+  - public_holiday: true
+    date: '2029-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2029-03-30'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2029-04-02'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2029-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2029-05-10'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2029-05-21'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2029-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2029-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2029-11-21'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2029-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2029-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2030':
+  - public_holiday: true
+    date: '2030-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2030-04-19'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2030-04-22'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2030-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2030-05-30'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2030-06-10'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2030-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2030-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2030-11-20'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2030-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2030-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2031':
+  - public_holiday: true
+    date: '2031-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2031-04-11'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2031-04-14'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2031-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2031-05-22'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2031-06-02'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2031-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2031-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2031-11-19'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2031-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2031-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2032':
+  - public_holiday: true
+    date: '2032-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2032-03-26'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2032-03-29'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2032-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2032-05-06'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2032-05-17'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2032-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2032-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2032-11-17'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2032-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2032-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2033':
+  - public_holiday: true
+    date: '2033-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2033-04-15'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2033-04-18'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2033-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2033-05-26'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2033-06-06'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2033-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2033-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2033-11-16'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2033-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2033-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2034':
+  - public_holiday: true
+    date: '2034-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2034-04-07'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2034-04-10'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2034-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2034-05-18'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2034-05-29'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2034-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2034-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2034-11-22'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2034-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2034-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2035':
+  - public_holiday: true
+    date: '2035-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2035-03-23'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2035-03-26'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2035-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2035-05-03'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2035-05-14'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2035-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2035-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2035-11-21'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2035-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2035-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2036':
+  - public_holiday: true
+    date: '2036-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2036-04-11'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2036-04-14'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2036-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2036-05-22'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2036-06-02'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2036-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2036-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2036-11-19'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2036-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2036-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2037':
+  - public_holiday: true
+    date: '2037-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2037-04-03'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2037-04-06'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2037-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2037-05-14'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2037-05-25'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2037-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2037-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2037-11-18'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2037-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2037-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2038':
+  - public_holiday: true
+    date: '2038-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2038-04-23'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2038-04-26'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2038-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2038-06-03'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2038-06-14'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2038-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2038-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2038-11-17'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2038-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2038-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2039':
+  - public_holiday: true
+    date: '2039-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2039-04-08'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2039-04-11'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2039-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2039-05-19'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2039-05-30'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2039-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2039-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2039-11-16'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2039-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2039-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag
+  '2040':
+  - public_holiday: true
+    date: '2040-01-01'
+    names:
+      en: New Year's Day
+      de: Neujahrstag
+  - public_holiday: true
+    date: '2040-03-30'
+    names:
+      en: Good Friday
+      de: Karfreitag
+  - public_holiday: true
+    date: '2040-04-02'
+    names:
+      en: Easter Monday
+      de: Ostermontag
+  - public_holiday: true
+    date: '2040-05-01'
+    names:
+      en: Labour Day
+      de: Tag der Arbeit
+  - public_holiday: true
+    date: '2040-05-10'
+    names:
+      en: Ascension Day
+      de: Christi Himmelfahrt
+  - public_holiday: true
+    date: '2040-05-21'
+    names:
+      en: Whit Monday
+      de: Pfingstmontag
+  - public_holiday: true
+    date: '2040-10-03'
+    names:
+      en: German Unity Day
+      de: Tag der Deutschen Einheit
+  - public_holiday: true
+    date: '2040-10-31'
+    names:
+      en: Reformation Day
+      de: Reformationstag
+  - public_holiday: true
+    date: '2040-11-21'
+    names:
+      en: Day of Repentance and Prayer
+      de: Buß- und Bettag
+  - public_holiday: true
+    date: '2040-12-25'
+    names:
+      en: Christmas Day
+      de: Weihnachtstag
+  - public_holiday: true
+    date: '2040-12-26'
+    names:
+      en: St. Stephen's Day
+      de: Zweiter Weihnachtsfeiertag


### PR DESCRIPTION
The `germany15.yaml` file currently only includes dates up to 2022, while other regional files already extend to 2040. This PR adds the missing dates for consistency across the dataset.

I’m from this region myself, so I noticed the discrepancy while exploring the repo.