### PR TITLE
Swap "Christmas Day" and "Boxing Day" 2027 for UK

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     json (2.10.1)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
-    minitest (5.25.4)
+    minitest (5.27.0)
     minitest-fail-fast (0.1.0)
       minitest (~> 5)
     minitest-reporters (1.7.1)
@@ -43,7 +43,7 @@ GEM
     unaccent (0.4.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   arm64-darwin-24

--- a/conf/gb/united_kingdom01.yml
+++ b/conf/gb/united_kingdom01.yml
@@ -577,11 +577,11 @@ years:
   - public_holiday: true
     date: '2027-12-27'
     names:
-      en: Boxing Day
+      en: Christmas Day
   - public_holiday: true
     date: '2027-12-28'
     names:
-      en: Christmas Day
+      en: Boxing Day
   '2028':
   - public_holiday: true
     date: '2028-01-03'

--- a/conf/gb/united_kingdom02.yml
+++ b/conf/gb/united_kingdom02.yml
@@ -577,11 +577,11 @@ years:
   - public_holiday: true
     date: '2027-12-27'
     names:
-      en: Boxing Day
+      en: Christmas Day
   - public_holiday: true
     date: '2027-12-28'
     names:
-      en: Christmas Day
+      en: Boxing Day
   '2028':
   - public_holiday: true
     date: '2028-01-03'

--- a/conf/gb/united_kingdom03.yml
+++ b/conf/gb/united_kingdom03.yml
@@ -613,11 +613,11 @@ years:
   - public_holiday: true
     date: '2027-12-27'
     names:
-      en: Boxing Day
+      en: Christmas Day
   - public_holiday: true
     date: '2027-12-28'
     names:
-      en: Christmas Day
+      en: Boxing Day
   '2028':
   - public_holiday: true
     date: '2028-01-03'

--- a/conf/gb/united_kingdom04.yml
+++ b/conf/gb/united_kingdom04.yml
@@ -673,11 +673,11 @@ years:
   - public_holiday: true
     date: '2027-12-27'
     names:
-      en: Boxing Day
+      en: Christmas Day
   - public_holiday: true
     date: '2027-12-28'
     names:
-      en: Christmas Day
+      en: Boxing Day
   '2028':
   - public_holiday: true
     date: '2028-01-03'

--- a/conf/gb/united_kingdom05.yml
+++ b/conf/gb/united_kingdom05.yml
@@ -577,11 +577,11 @@ years:
   - public_holiday: true
     date: '2027-12-27'
     names:
-      en: Boxing Day
+      en: Christmas Day
   - public_holiday: true
     date: '2027-12-28'
     names:
-      en: Christmas Day
+      en: Boxing Day
   '2028':
   - public_holiday: true
     date: '2028-01-03'

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,6 +1,6 @@
 # Coverage
 
-Last updated 2026-02-23.
+Last updated 2026-07-10.
 
 | Flag | Country | Region | Latest Public Holidays Year | Known Public Holidays | Latest Non-public Holidays Year | Known Non-public Holidays |
 | ---- | ------- | ------ | --------------------------- | --------------------- | ------------------------------- | ------------------------- |


### PR DESCRIPTION
A member of Charlie pointed out that in 2027, Christmas Day in lieu and Boxing Day in lieu  were displaying the wrong way round. This swaps them so that Christmas Day appears on the 27th December and Boxing Day appears on the 28th December. This is true for all 5 UK regions. (No other regions were affected).

<img width="2616" height="1246" alt="Screenshot 2026-07-08 at 16 38 43" src="https://github.com/user-attachments/assets/a047969f-18c6-42b7-a54c-24a48c852269" />